### PR TITLE
Fixes the ALT+number issue (see issue #9) which indexes the tabs from the last

### DIFF
--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -378,7 +378,7 @@ static gboolean goto_tab_generic (tilda_window *tw, guint tab_number)
 
     if (g_list_length (tw->terms) > (tab_number-1))
     {
-        goto_tab (tw, g_list_length (tw->terms) - tab_number);
+        goto_tab (tw, tab_number - 1);
         return TRUE;
     }
 


### PR DESCRIPTION
tilda_window.c: goto_tab_generic now counts from zero based tab index, instead of counting backward from the last tab
