### PR TITLE
Notebook is scrollable so long tab names don't break window size

### DIFF
--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -601,6 +601,7 @@ tilda_window *tilda_window_init (const gchar *config_file, const gint instance)
     gtk_notebook_set_show_tabs (GTK_NOTEBOOK(tw->notebook), FALSE);
     gtk_notebook_set_show_border (GTK_NOTEBOOK (tw->notebook),
         config_getbool("notebook_border"));
+    gtk_notebook_set_scrollable (GTK_NOTEBOOK(tw->notebook), TRUE);
     tilda_window_set_tab_position (tw, config_getint ("tab_pos"));
 
     provider = gtk_css_provider_new ();


### PR DESCRIPTION
This is a workaround for issue #15.  

Tabs still look a little ugly.  It would be nicer if tilda displayed the last N characters of the existing tab name rather than the entire massive thing.  I don't plan to add that to this pull request though.
