### PR TITLE
Set window size to default when unfullscreening.

### DIFF
--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -121,14 +121,18 @@ gint toggle_fullscreen_cb (tilda_window *tw)
     DEBUG_FUNCTION ("toggle_fullscreen_cb");
     DEBUG_ASSERT (tw != NULL);
 
-	if (tw->fullscreen != TRUE) {
-		tw->fullscreen = TRUE;
-		gtk_window_fullscreen (GTK_WINDOW (tw->window));
-	}
-	else {
-		gtk_window_unfullscreen (GTK_WINDOW (tw->window));
-		tw->fullscreen = FALSE;
-	}
+    if (tw->fullscreen != TRUE) {
+        tw->fullscreen = TRUE;
+        gtk_window_fullscreen (GTK_WINDOW (tw->window));
+    }
+    else {
+        gtk_window_unfullscreen (GTK_WINDOW (tw->window));
+        // This appears to be necssary on (at least) xfwm4 if you tabbed out
+        // while fullscreened.
+        gtk_window_set_default_size (GTK_WINDOW(tw->window), config_getint ("max_width"), config_getint ("max_height"));
+        gtk_window_resize (GTK_WINDOW(tw->window), config_getint ("max_width"), config_getint ("max_height"));
+        tw->fullscreen = FALSE;
+    }
 
     // It worked. Having this return GDK_EVENT_STOP makes the callback not carry the
     // keystroke into the vte terminal widget.


### PR DESCRIPTION
This works around problems in xfwm4 (maybe others?) where tabbing out of tilda 
(e.g. to change desktop) when fullscreened will mean a subsequent unfullscreen 
won't restore the dimensions of the window.

I'm sure there must be a better way to do this but I can't see any obvious point 
where the dimension info is lost so I used the brute force method.  I'm guessing 
that this patch will have the limitation that if you set a custom dimension then
it won't be restored properly.

So consider this my best guess which solves my immediate problem.

Here are the steps to reproduce the error:
- ctrl+f1 = go to desktop 1
- f1 = drop down tilda
- f11 = toggle fullscreen
- ctrl+f2 = go to desktop 2
- f1 = minimise tilda [1]
- f1 = drop down tilda
- f11 = unfullscreen

Outcome: position has been restored, but not dimensions.

If you do not minimise tilda [1] then unfullscreen works as expected.  If you change the width in the settings then it will fix the problem too.

Anyone got a better fix?
