### PR TITLE
Rename tab functionality, still work in progress..

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ INSTALL
 .project
 .cproject
 .kdev4
+.settings

--- a/src/configsys.c
+++ b/src/configsys.c
@@ -32,6 +32,7 @@ static cfg_opt_t config_opts[] = {
     CFG_STR("addtab_key", "<Shift><Control>t", CFGF_NONE),
     CFG_STR("fullscreen_key", "F11", CFGF_NONE),
     CFG_STR("closetab_key", "<Shift><Control>w", CFGF_NONE),
+    CFG_STR("renametab_key", "<Shift>F2", CFGF_NONE),
     CFG_STR("nexttab_key", "<Control>Page_Down", CFGF_NONE),
     CFG_STR("prevtab_key", "<Control>Page_Up", CFGF_NONE),
     CFG_STR("movetableft_key", "<Shift><Control>Page_Up", CFGF_NONE),

--- a/src/configsys.c
+++ b/src/configsys.c
@@ -32,7 +32,7 @@ static cfg_opt_t config_opts[] = {
     CFG_STR("addtab_key", "<Shift><Control>t", CFGF_NONE),
     CFG_STR("fullscreen_key", "F11", CFGF_NONE),
     CFG_STR("closetab_key", "<Shift><Control>w", CFGF_NONE),
-    CFG_STR("renametab_key", "<Shift>F2", CFGF_NONE),
+    CFG_STR("renametab_key", "F2", CFGF_NONE),
     CFG_STR("nexttab_key", "<Control>Page_Down", CFGF_NONE),
     CFG_STR("prevtab_key", "<Control>Page_Up", CFGF_NONE),
     CFG_STR("movetableft_key", "<Shift><Control>Page_Up", CFGF_NONE),

--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -728,6 +728,17 @@ menu_close_tab_cb (GtkWidget *widget, gpointer data)
     tilda_window_close_current_tab (TILDA_WINDOW(data));
 }
 
+static void
+menu_rename_tab_cb (GtkWidget *widget, gpointer data)
+{
+    DEBUG_FUNCTION ("menu_rename_tab_cb");
+    DEBUG_ASSERT (widget != NULL);
+    DEBUG_ASSERT (data != NULL);
+
+    tilda_window_rename_current_tab (TILDA_WINDOW(data), "test");
+}
+
+
 static void on_popup_hide (GtkWidget *widget, gpointer data)
 {
     DEBUG_FUNCTION("on_popup_hide");
@@ -757,6 +768,7 @@ static void popup_menu (tilda_window *tw, tilda_term *tt)
             "<popup name=\"popup-menu\">"
                 "<menuitem action=\"new-tab\" />"
                 "<menuitem action=\"close-tab\" />"
+    			"<menuitem action=\"rename-tab\" />"
                 "<separator />"
                 "<menuitem action=\"copy\" />"
                 "<menuitem action=\"paste\" />"
@@ -781,9 +793,9 @@ static void popup_menu (tilda_window *tw, tilda_term *tt)
     gtk_action_group_add_action_with_accel (action_group, action, config_getstr("closetab_key"));
     g_signal_connect (G_OBJECT(action), "activate", G_CALLBACK(menu_close_tab_cb), tw);
 
-    action = gtk_action_new ("rename-tab", _("_Rename Tab"), NULL, GTK_STOCK_CLOSE);
-    gtk_action_group_add_action_with_accel (action_group, action, config_getstr("renametab_key"));
-    g_signal_connect (G_OBJECT(action), "activate", G_CALLBACK(menu_close_tab_cb), tw);
+    action = gtk_action_new ("rename-tab", _("_Rename Tab"), NULL, GTK_STOCK_REFRESH);
+    gtk_action_group_add_action_with_accel (action_group, action, config_getstr("closetab_key"));
+    g_signal_connect (G_OBJECT(action), "activate", G_CALLBACK(menu_rename_tab_cb), tw);
 
     action = gtk_action_new ("copy", NULL, NULL, GTK_STOCK_COPY);
     gtk_action_group_add_action_with_accel (action_group, action, config_getstr("copy_key"));

--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -781,6 +781,10 @@ static void popup_menu (tilda_window *tw, tilda_term *tt)
     gtk_action_group_add_action_with_accel (action_group, action, config_getstr("closetab_key"));
     g_signal_connect (G_OBJECT(action), "activate", G_CALLBACK(menu_close_tab_cb), tw);
 
+    action = gtk_action_new ("rename-tab", _("_Rename Tab"), NULL, GTK_STOCK_CLOSE);
+    gtk_action_group_add_action_with_accel (action_group, action, config_getstr("renametab_key"));
+    g_signal_connect (G_OBJECT(action), "activate", G_CALLBACK(menu_close_tab_cb), tw);
+
     action = gtk_action_new ("copy", NULL, NULL, GTK_STOCK_COPY);
     gtk_action_group_add_action_with_accel (action_group, action, config_getstr("copy_key"));
     g_signal_connect (G_OBJECT(action), "activate", G_CALLBACK(menu_copy_cb), tt);

--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -23,7 +23,6 @@
 #include <callback_func.h>
 #include <configsys.h>
 #include <wizard.h> /* wizard */
-#include <gtk/gtk.h>
 
 #include <stdio.h>
 #include <stdlib.h> /* malloc */
@@ -735,7 +734,7 @@ menu_rename_tab_cb (GtkWidget *widget, gpointer data)
     DEBUG_ASSERT (widget != NULL);
     DEBUG_ASSERT (data != NULL);
 
-    tilda_window_rename_current_tab (TILDA_WINDOW(data), "test");
+    tilda_window_rename_current_tab(TILDA_WINDOW(data));
 }
 
 

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -91,6 +91,15 @@ void tilda_window_close_current_tab (tilda_window *tw)
     tilda_window_close_tab (tw, pos, FALSE);
 }
 
+void tilda_window_rename_current_tab (tilda_window *tw, gchar* title)
+{
+    DEBUG_FUNCTION ("close_current_tab");
+    DEBUG_ASSERT (tw != NULL);
+
+    gint pos = gtk_notebook_get_current_page (GTK_NOTEBOOK (tw->notebook));
+    tilda_window_rename_tab (tw, pos, title);
+}
+
 
 gint tilda_window_set_tab_position (tilda_window *tw, enum notebook_tab_positions pos)
 {
@@ -471,13 +480,14 @@ gint tilda_window_setup_keyboard_accelerators (tilda_window *tw)
     /* Set up keyboard shortcuts for Exit, Next Tab, Previous Tab,
        Move Tab, Add Tab, Close Tab, Copy, and Paste using key
        combinations defined in the config. */
-    tilda_add_config_accelerator("quit_key",         G_CALLBACK(gtk_main_quit),                  tw);
+    tilda_add_config_accelerator("quit_key",         G_CALLBACK(gtk_main_quit),                tw);
     tilda_add_config_accelerator("nexttab_key",      G_CALLBACK(next_tab),                       tw);
     tilda_add_config_accelerator("prevtab_key",      G_CALLBACK(prev_tab),                       tw);
     tilda_add_config_accelerator("movetableft_key",  G_CALLBACK(move_tab_left),                  tw);
     tilda_add_config_accelerator("movetabright_key", G_CALLBACK(move_tab_right),                 tw);
     tilda_add_config_accelerator("addtab_key",       G_CALLBACK(tilda_window_add_tab),           tw);
     tilda_add_config_accelerator("closetab_key",     G_CALLBACK(tilda_window_close_current_tab), tw);
+    tilda_add_config_accelerator("renametab_key",    G_CALLBACK(tilda_window_rename_current_tab),tw);
     tilda_add_config_accelerator("copy_key",         G_CALLBACK(ccopy),                          tw);
     tilda_add_config_accelerator("paste_key",        G_CALLBACK(cpaste),                         tw);
     tilda_add_config_accelerator("fullscreen_key",   G_CALLBACK(toggle_fullscreen_cb),           tw);
@@ -785,6 +795,38 @@ gint tilda_window_close_tab (tilda_window *tw, gint tab_index, gboolean force_ex
 
     /* Free the terminal, we are done with it */
     tilda_term_free (tt);
+
+    return 0;
+}
+
+gint tilda_window_rename_tab (tilda_window *tw, gint tab_index, gchar* title) {
+
+    DEBUG_FUNCTION ("tilda_window_rename_tab");
+    DEBUG_ASSERT (tw != NULL);
+    DEBUG_ASSERT (tab_index >= 0);
+
+    tilda_term *tt;
+    GtkWidget *label;
+
+    tt = find_tt_in_g_list (tw, tab_index);
+    label = gtk_notebook_get_tab_label (GTK_NOTEBOOK (tt->tw->notebook), tt->hbox);
+
+    if (label == NULL)
+    {
+        DEBUG_ERROR ("Bad tab_index specified");
+        return -1;
+    }
+
+    guint length = config_getint ("title_max_length");
+
+	if(config_getbool("title_max_length_flag") && strlen(title) > length) {
+		gchar *titleOffset = title + strlen(title) - length;
+		gchar *shortTitle = g_strdup_printf ("...%s", titleOffset);
+		gtk_label_set_text (GTK_LABEL(label), shortTitle);
+		g_free(shortTitle);
+	} else {
+		gtk_label_set_text (GTK_LABEL(label), "test");
+	}
 
     return 0;
 }

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -129,30 +129,6 @@ void tilda_window_rename_current_tab (tilda_window *tw)
 	}
 }
 
-
-void create_dialog(GtkWidget *button, gpointer window) {
-
-    GtkWidget *dialog, *label, *content_area;
-
-    /* New label for dialog content */
-    label = gtk_label_new("This is a dialog!");
-
-    /* Make a new dialog with an 'OK' button */
-    dialog = gtk_dialog_new_with_buttons("This is a dialog, which (shouldn't | can't) be resized!", window, GTK_DIALOG_DESTROY_WITH_PARENT, GTK_STOCK_OK, GTK_RESPONSE_NONE, NULL);
-
-    /* Add label to dialog */
-    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
-    gtk_container_add(GTK_CONTAINER(content_area), label);
-
-    /* Destroy dialog properly */
-    g_signal_connect(dialog, "response", G_CALLBACK(gtk_widget_destroy), dialog);
-
-    /* Set dialog to not resize. */
-    gtk_window_set_resizable(GTK_WINDOW(dialog), FALSE);
-
-    gtk_widget_show_all(dialog);
-}
-
 gint tilda_window_set_tab_position (tilda_window *tw, enum notebook_tab_positions pos)
 {
     switch (pos)

--- a/src/tilda_window.h
+++ b/src/tilda_window.h
@@ -61,6 +61,14 @@ struct tilda_window_
     enum tilda_positions { UP, DOWN } current_state;
 };
 
+typedef struct rename_data_ rename_data;
+
+struct rename_data_ {
+	tilda_window* tw;
+	GtkDialog* dialog;
+	GtkWidget* entry;
+};
+
 enum notebook_tab_positions { NB_TOP, NB_BOTTOM, NB_LEFT, NB_RIGHT };
 
 /**
@@ -91,7 +99,7 @@ gint tilda_window_close_tab (tilda_window *tw, gint tab_position, gboolean force
  * Success: return 0
  * Failure: return non-zero
  */
-gint tilda_window_rename_tab (tilda_window *tw, gint tab_index, gchar* title);
+gint tilda_window_rename_tab (tilda_window *tw, gint tab_index, const gchar* title);
 
 /**
  * tilda_window_init ()
@@ -134,7 +142,7 @@ void tilda_window_close_current_tab (tilda_window *tw);
  *
  * Renames the current tab
  */
-void tilda_window_rename_current_tab (tilda_window *tw, gchar* title);
+void tilda_window_rename_current_tab (tilda_window *tw);
 
 /**
  * This registers the keyboard shortcuts to the values which the user has

--- a/src/tilda_window.h
+++ b/src/tilda_window.h
@@ -84,6 +84,16 @@ gint tilda_window_add_tab (tilda_window *tw);
 gint tilda_window_close_tab (tilda_window *tw, gint tab_position, gboolean force_exit);
 
 /**
+ * tilda_window_rename_tab ()
+ *
+ * Renames the tab at the given tab index (starting from 0)
+ *
+ * Success: return 0
+ * Failure: return non-zero
+ */
+gint tilda_window_rename_tab (tilda_window *tw, gint tab_index, gchar* title);
+
+/**
  * tilda_window_init ()
  *
  * Create a new tilda_window * and return it. It will also initialize and set up
@@ -115,9 +125,16 @@ gint tilda_window_set_tab_position (tilda_window *tw, enum notebook_tab_position
 /**
  * tilda_window_close_tab ()
  *
- * Closes the tab current tab
+ * Closes the current tab
  */
 void tilda_window_close_current_tab (tilda_window *tw);
+
+/**
+ * tilda_window_renam_tab ()
+ *
+ * Renames the current tab
+ */
+void tilda_window_rename_current_tab (tilda_window *tw, gchar* title);
 
 /**
  * This registers the keyboard shortcuts to the values which the user has

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -1815,7 +1815,7 @@ static void button_keybinding_clicked_cb (GtkWidget *w)
     gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_fullscreen), FALSE);
 
     /* Bring up the dialog that will accept the new keybinding */
-    GtkWidget *dialog = gtk_message_dialog_new (GTK_WINDOW(wizard_window),
+    GtkWidget* dialog = gtk_message_dialog_new (GTK_WINDOW(wizard_window),
                               GTK_DIALOG_DESTROY_WITH_PARENT,
                               GTK_MESSAGE_QUESTION,
                               GTK_BUTTONS_CANCEL,

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -342,6 +342,7 @@ static void wizard_closed ()
     const gchar *key = GET_BUTTON_LABEL("button_keybinding_pulldown");
     const gchar *addtab_key = GET_BUTTON_LABEL("button_keybinding_addtab");
     const gchar *closetab_key = GET_BUTTON_LABEL("button_keybinding_closetab");
+    const gchar *renametab_key = GET_BUTTON_LABEL("button_keybinding_renametab");
     const gchar *nexttab_key = GET_BUTTON_LABEL("button_keybinding_nexttab");
     const gchar *prevtab_key = GET_BUTTON_LABEL("button_keybinding_prevtab");
     const gchar *movetableft_key = GET_BUTTON_LABEL("button_keybinding_movetableft");
@@ -377,6 +378,8 @@ static void wizard_closed ()
     if (!validate_keybinding(addtab_key, wizard_window, _("The keybinding you chose for \"Add Tab\" is invalid. Please choose another.")))
         return;
     if (!validate_keybinding(closetab_key, wizard_window, _("The keybinding you chose for \"Close Tab\" is invalid. Please choose another.")))
+        return;
+    if (!validate_keybinding(renametab_key, wizard_window, _("The keybinding you chose for \"Rename Tab\" is invalid. Please choose another.")))
         return;
     if (!validate_keybinding(nexttab_key, wizard_window, _("The keybinding you chose for \"Next Tab\" is invalid. Please choose another.")))
         return;
@@ -419,6 +422,7 @@ static void wizard_closed ()
     config_setstr ("key", key);
     config_setstr ("addtab_key", addtab_key);
     config_setstr ("closetab_key", closetab_key);
+    config_setstr ("renametab_key", renametab_key);
     config_setstr ("nexttab_key", nexttab_key);
     config_setstr ("prevtab_key", prevtab_key);
     config_setstr ("movetableft_key", movetableft_key);
@@ -1764,6 +1768,7 @@ static void button_keybinding_clicked_cb (GtkWidget *w)
     const GtkWidget *button_keybinding_pulldown =     GTK_WIDGET (gtk_builder_get_object (xml, "button_keybinding_pulldown"));
     const GtkWidget *button_keybinding_addtab =       GTK_WIDGET (gtk_builder_get_object (xml, "button_keybinding_addtab"));
     const GtkWidget *button_keybinding_closetab =     GTK_WIDGET (gtk_builder_get_object (xml, "button_keybinding_closetab"));
+    const GtkWidget *button_keybinding_renametab =    GTK_WIDGET (gtk_builder_get_object (xml, "button_keybinding_renametab"));
     const GtkWidget *button_keybinding_nexttab =      GTK_WIDGET (gtk_builder_get_object (xml, "button_keybinding_nexttab"));
     const GtkWidget *button_keybinding_prevtab =      GTK_WIDGET (gtk_builder_get_object (xml, "button_keybinding_prevtab"));
     const GtkWidget *button_keybinding_movetableft =  GTK_WIDGET (gtk_builder_get_object (xml, "button_keybinding_movetableft"));
@@ -1789,6 +1794,7 @@ static void button_keybinding_clicked_cb (GtkWidget *w)
     gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_pulldown), FALSE);
     gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_addtab), FALSE);
     gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_closetab), FALSE);
+    gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_renametab), FALSE);
     gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_nexttab), FALSE);
     gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_prevtab), FALSE);
     gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_movetableft), FALSE);
@@ -1829,6 +1835,7 @@ static void button_keybinding_clicked_cb (GtkWidget *w)
     gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_pulldown), TRUE);
     gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_addtab), TRUE);
     gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_closetab), TRUE);
+    gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_renametab), FALSE);
     gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_nexttab), TRUE);
     gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_prevtab), TRUE);
     gtk_widget_set_sensitive (GTK_WIDGET(button_keybinding_movetableft), TRUE);
@@ -2033,6 +2040,7 @@ static void set_wizard_state_from_config () {
     BUTTON_LABEL_FROM_CFG ("button_keybinding_pulldown", "key");
     BUTTON_LABEL_FROM_CFG ("button_keybinding_addtab", "addtab_key");
     BUTTON_LABEL_FROM_CFG ("button_keybinding_closetab", "closetab_key");
+    BUTTON_LABEL_FROM_CFG ("button_keybinding_renametab", "renametab_key");
     BUTTON_LABEL_FROM_CFG ("button_keybinding_nexttab", "nexttab_key");
     BUTTON_LABEL_FROM_CFG ("button_keybinding_prevtab", "prevtab_key");
     BUTTON_LABEL_FROM_CFG ("button_keybinding_movetableft", "movetableft_key");
@@ -2146,6 +2154,7 @@ static void connect_wizard_signals ()
     CONNECT_SIGNAL ("button_keybinding_quit","clicked",button_keybinding_clicked_cb);
     CONNECT_SIGNAL ("button_keybinding_addtab","clicked",button_keybinding_clicked_cb);
     CONNECT_SIGNAL ("button_keybinding_closetab","clicked",button_keybinding_clicked_cb);
+    CONNECT_SIGNAL ("button_keybinding_renametab","clicked",button_keybinding_clicked_cb);
     CONNECT_SIGNAL ("button_keybinding_nexttab","clicked",button_keybinding_clicked_cb);
     CONNECT_SIGNAL ("button_keybinding_prevtab","clicked",button_keybinding_clicked_cb);
     CONNECT_SIGNAL ("button_keybinding_movetableft","clicked",button_keybinding_clicked_cb);

--- a/tilda.glade
+++ b/tilda.glade
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.16.0 on Fri Nov 15 22:14:50 2013 -->
 <interface>
   <!-- interface-requires gtk+ 3.0 -->
   <object class="GtkAdjustment" id="adjustment1">
@@ -3675,9 +3676,6 @@
                   </packing>
                 </child>
                 <child>
-                  <placeholder/>
-                </child>
-                <child>
                   <object class="GtkFrame" id="frame_keybinding_fullscreen">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -3708,6 +3706,46 @@
                     </child>
                   </object>
                   <packing>
+                    <property name="top_attach">10</property>
+                    <property name="bottom_attach">11</property>
+                    <property name="y_options"/>
+                    <property name="x_padding">4</property>
+                    <property name="y_padding">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkFrame" id="frame_keybinding_renametab">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label_xalign">0</property>
+                    <child>
+                      <object class="GtkAlignment" id="alignment41">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="left_padding">12</property>
+                        <child>
+                          <object class="GtkButton" id="button_keybinding_renametab">
+                            <property name="label" translatable="yes"> </property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="margin_right">2</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel" id="label_keybinding_renametab">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Rename Tab&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
                     <property name="top_attach">10</property>
                     <property name="bottom_attach">11</property>
                     <property name="y_options"/>

--- a/tilda.glade
+++ b/tilda.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.16.0 on Fri Nov 15 22:14:50 2013 -->
+<!-- Generated with glade 3.16.0 on Fri Nov 15 23:50:45 2013 -->
 <interface>
   <!-- interface-requires gtk+ 3.0 -->
   <object class="GtkAdjustment" id="adjustment1">


### PR DESCRIPTION
Hi I have implemented a simple rename tab functionality. It's still work in progress because for now it uses a dialog to ask for the new name. I would prefer using in place edit on the tab but I'm not very experienced in GTK so I am having some difficulties. At the moment you can rename the tab by right click menu or shortcut, which is configurable from the settings panel.

Would you like to check the mod and, in case, provide an implementation solution I can use for that, in place editing, behavior? The best solution I was thinking of was hiding the label on the tab and placing there a GtkEntry until the text is entered. Also, the code is not organized well yet (functions position, names etc) so don't mind that thing.
