### PR TITLE
Allocate the struct 'tilda_window' on the stack of 'main()'.

### DIFF
--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -524,19 +524,13 @@ static gboolean delete_event_callback (G_GNUC_UNUSED GtkWidget *widget,
     return FALSE;
 }
 
-tilda_window *tilda_window_init (const gchar *config_file, const gint instance)
+tilda_window *tilda_window_init (const gchar *config_file, const gint instance, tilda_window *tw)
 {
     DEBUG_FUNCTION ("tilda_window_init");
     DEBUG_ASSERT (instance >= 0);
 
-    tilda_window *tw;
     GtkCssProvider *provider;
     GtkStyleContext *style_context;
-
-    tw = g_malloc (sizeof(tilda_window));
-
-    if (tw == NULL)
-        return NULL;
 
     /* Set the instance number */
     tw->instance = instance;

--- a/src/tilda_window.h
+++ b/src/tilda_window.h
@@ -86,7 +86,7 @@ gint tilda_window_close_tab (tilda_window *tw, gint tab_position, gboolean force
 /**
  * tilda_window_init ()
  *
- * Create a new tilda_window * and return it. It will also initialize and set up
+ * Initalized an already allocated tilda_window *. It will also initialize and set up
  * as much of the window as possible using the values in the configuation system.
  *
  * @param instance the instance number of this tilda_window
@@ -96,9 +96,7 @@ gint tilda_window_close_tab (tilda_window *tw, gint tab_position, gboolean force
  *
  * Notes: The configuration system must be up and running before calling this function.
  */
-tilda_window *tilda_window_init (const gchar *config_file, const gint instance);
-
-gint tilda_window_free (tilda_window *tw);
+tilda_window *tilda_window_init (const gchar *config_file, const gint instance, tilda_window *tw);
 
 /**
  * This toggles the fullscreen mode on or off. This is intended to be registered


### PR DESCRIPTION
The lifetime of the 'tilda_window' instance is exactly the same
as the 'main()' function (it doesn't get (de-)allocated anywhere
else), so we might as well allocate it on the stack of the 'main()'
function.

Apart from the (minor) benefit of avoiding a heap allocation,
this removes a bit of the necessary error handling.
