### PR TITLE
Free memory allocated by the option parser.

### DIFF
--- a/src/tilda.c
+++ b/src/tilda.c
@@ -351,19 +351,28 @@ static gboolean parse_cli (int argc, char *argv[])
     }
 
     /* Now set the options in the config, if they changed */
-    if (background_color != config_getstr ("background_color"))
+    if (background_color != config_getstr ("background_color")) {
         config_setstr ("background_color", background_color);
+        g_free(background_color);
+    }
     if (command != config_getstr ("command"))
     {
         config_setbool ("run_command", TRUE);
         config_setstr ("command", command);
+        g_free(command);
     }
-    if (font != config_getstr ("font"))
+    if (font != config_getstr ("font")) {
         config_setstr ("font", font);
-    if (image != config_getstr ("image"))
+        g_free(font);
+    }
+    if (image != config_getstr ("image")) {
         config_setstr ("image", image);
-    if (working_dir != config_getstr ("working_dir"))
+        g_free(image);
+    }
+    if (working_dir != config_getstr ("working_dir")) {
         config_setstr ("working_dir", working_dir);
+        g_free(working_dir);
+    }
 
     if (lines != config_getint ("lines"))
         config_setint ("lines", lines);


### PR DESCRIPTION
Since confuse makes a copy of strings it stores[1] and the glib
option parser allocates strings (and says in the documentation[2] one
should free the strings with 'g_free()'), we should indeed free them
to avoid leaks.

[1] http://www.nongnu.org/confuse/manual/confuse_8h.html#dd02a10fac10c9b028c1438dff28343f
[2] https://developer.gnome.org/glib/2.39/glib-Commandline-option-parser.html#GOptionEntry
