### PR TITLE
Cleaned up finding of free lock instance

### DIFF
--- a/src/tilda.c
+++ b/src/tilda.c
@@ -418,6 +418,10 @@ static gchar *get_config_file_name (gint instance)
     return config_file;
 }
 
+static gint _cmp_locks(gint a, gint b) {
+  return a - b;
+}
+
 /**
  * get_instance_number ()
  *
@@ -434,8 +438,12 @@ static gint get_instance_number ()
     gint i;
     gchar *name;
 
+    GSequence *seq;
+    GSequenceIter *iter;
+    gint lowest_lock_instance = 0;
+    gint current_lock_instance;
+
     GDir *dir;
-    gint lowest_lock_instance = INT_MIN;
     struct lock_info *lock;
     gchar *lock_dir = g_build_filename (g_get_user_cache_dir (), "tilda", "locks", NULL);
 
@@ -451,14 +459,15 @@ static gint get_instance_number ()
     }
 
     /* Look through every file in the lock directory, and see if it is a lock file.
-     * If it is a lock file, check if it's the lowest lock instance (and store it if it is). */
+     * If it is a lock file, insert it in a sorted sequence. */
+    seq = g_sequence_new(NULL);
     while ((name = (gchar*)g_dir_read_name (dir)) != NULL)
     {
         lock = islockfile (name);
 
         if (lock != NULL)
         {
-            lowest_lock_instance = max(lock->instance, lowest_lock_instance);
+            g_sequence_insert_sorted(seq, GINT_TO_POINTER(lock->instance), (GCompareDataFunc)_cmp_locks, NULL);
             g_free (lock);
         }
     }
@@ -466,12 +475,18 @@ static gint get_instance_number ()
     g_dir_close (dir);
     g_free (lock_dir);
 
-    /**
-     * If no lockfile exists, then the lowest_lock_instance will still be
-     * set to INT_MAX. In that case we need to return 0, otherwise we should return
-     * the next free lock instance, which is one more then the lowest_lock_instance.
-     */
-    return (lowest_lock_instance == INT_MIN ? 0 : lowest_lock_instance + 1);
+    /* We iterate the sorted sequence of lock instances to find the first (lowest) number *not* taken. */
+    for (iter = g_sequence_get_begin_iter(seq); !g_sequence_iter_is_end(iter); iter = g_sequence_iter_next(iter)) {
+      current_lock_instance = GPOINTER_TO_INT(g_sequence_get(iter));
+      if (lowest_lock_instance < current_lock_instance)
+        break;
+      else
+        lowest_lock_instance = current_lock_instance + 1;
+    }
+
+    g_sequence_free(seq);
+
+    return lowest_lock_instance;
 }
 
 static void termination_handler (G_GNUC_UNUSED gint signum) {


### PR DESCRIPTION
The previous algorithm had a O(n**2) list creation and O(n**2) search
for the lowest not-taken lock instance. One could argue that
the numbers involved are small enough to not make a difference, but
this version has a O(n logn) list creation and O(n) search without being
more complicated, so it might be worth it.

This is rebased on the current master and should merge cleanly. Sorry for the mess!
