### PR TITLE
Fixed focus issue with some java/swing applications (e.g. netbeans)

### DIFF
--- a/src/key_grabber.c
+++ b/src/key_grabber.c
@@ -138,7 +138,7 @@ void tilda_window_set_active (tilda_window *tw)
     {
         guint32 timestamp = gtk_get_current_event_time ();
         if (timestamp == 0) {
-            timestamp = tomboy_keybinder_get_current_event_time ();
+            timestamp = gdk_x11_get_server_time(gtk_widget_get_root_window (tw->window));
         }
         event.xclient.type = ClientMessage;
         event.xclient.serial = 0;


### PR DESCRIPTION
When using tilda while working in netbeans the focus did not switch to
tilda when it was pulled down by key.

Forcing the tilda_window_set_active method to use the current x11 server
time instead of using the event time reported by tomboykebinder solves
this issue.

I can't figure out exactly why the default behaviour does not work
with those applications but this fix works for me.

Note: I also noticed that the terminal cursor often looks as if it does not have the focus (unfilled) but typing is possible (does neither depend on running programs nor my fix).

Tested on Ubuntu 12.04, xfwm4 4.10.1, netbeans 7.4
