### PR TITLE
Always capture tab changes

### DIFF
--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -383,10 +383,9 @@ static gboolean goto_tab_generic (tilda_window *tw, guint tab_number)
     if (g_list_length (tw->terms) > (tab_number-1))
     {
         goto_tab (tw, tab_number - 1);
-        return TRUE;
     }
 
-    return FALSE;
+    return TRUE;
 }
 
 /* These all just call the generic function since they're all basically the same


### PR DESCRIPTION
Just a quick one after battling all day with gtk docs.

Key presses which are bound to the switch to tab will be sent to the terminal if you don't have that number of tabs open.  For example if you bind ALT+N, have 1 tab, and press ALT+2 you get bash's readline arguments behaviour in the shell you have currently active.

This patch means that the key press is swallowed even if you select a tab number higher than can be switched to.
