### PR TITLE
Don't set tilda active when sub-windows are open.

### DIFF
--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -325,11 +325,8 @@ static gboolean mouse_enter (GtkWidget *widget, G_GNUC_UNUSED GdkEvent *event, g
     DEBUG_ASSERT (data != NULL);
     DEBUG_ASSERT (widget != NULL);
 
-    GdkEventCrossing *ev = (GdkEventCrossing*)event;
     tilda_window *tw = TILDA_WINDOW(data);
     stop_auto_hide_tick(tw);
-    if (tw->disable_auto_hide == FALSE && ev->time != 0)
-        tilda_window_set_active(tw);
 
     return GDK_EVENT_STOP;
 }


### PR DESCRIPTION
I had some problems with the commit in 1bd3bbf.  Since I have tilda configured to take up most of the screen, when I right click and select "preferences", my mouse hits the tilda window after the preferences are created.  The preferences are then stuck below the tilda window and I can neither use them, nor use the pulldown key to get tilda out of the way!

I can't quite work out why tilda_window_set_active should be called at all on mouseover because the window should already be focused as soon as it is pulled down.

I'm a little unsure of what 1bd3bbf was intended to do so all I've done is revert the patch.  Perhaps the original author @aperkins81 could give some more information here?

Edit: reading closer I see this is to do with #18 .
