### PR TITLE
Inherit working dir on new tab, fixes #68

### DIFF
--- a/src/configsys.c
+++ b/src/configsys.c
@@ -136,6 +136,8 @@ static cfg_opt_t config_opts[] = {
     CFG_BOOL("auto_hide_on_mouse_leave", FALSE, CFGF_NONE),
     /* Whether we limit the length of a tab title */
     CFG_BOOL("title_max_length_flag", TRUE, CFGF_NONE),
+    /* Whether to set a new tab's working dir to the current tab's */
+    CFG_BOOL("inherit_working_dir", TRUE, CFGF_NONE),
     CFG_END()
 };
 

--- a/src/tilda_terminal.h
+++ b/src/tilda_terminal.h
@@ -31,6 +31,7 @@ struct tilda_term_
     GtkWidget *hbox;
     GtkWidget *scrollbar;
     GRegex *http_regexp;
+    GPid pid;
     /* We remember if we have already dropped to the default
      * shell before, if so, then we know that this time we can
      * exit the program.
@@ -73,6 +74,7 @@ gint tilda_term_free (struct tilda_term_ *term);
 
 
 void tilda_term_set_scrollbar_position (tilda_term *tt, enum tilda_term_scrollbar_positions pos);
+char* tilda_term_get_cwd(tilda_term* tt);
 
 #define TILDA_TERM(tt) ((tilda_term *)(tt))
 


### PR DESCRIPTION
Pids of child terms are saved on the `tilda_terminal` struct. This pid is used to get the working directory of the active terminal when creating a new tab, by looking at `/proc/<pid>/cwd`.  This working directory is passed to 
`vte_terminal_fork_command_full` for initialization.

The function `tilda_term_get_cwd` is based on these:
https://github.com/skawouter/svte/blob/524835cb00cd8cc7653f72b21d3c266bd6ab50ce/svte.c#L169
https://github.com/mate-desktop/mate-terminal/blob/master/src/terminal-screen.c#L200

I don't know what your portability standards are, but I think it only works on Linux.

I've added a setting `inherit_working_dir` defaulted to `TRUE`, but have not exposed it to the user.  Not sure where it should go in the Preferences UI or if it should be part of the CLI.  If `FALSE` it will follow the old behavior, which was to use the `"working_dir"` config which can be NULL and vte will use tilda's working directory in that case.
