### PR TITLE
Option to select how pull-up behave on non-focused terminal

### DIFF
--- a/src/configsys.c
+++ b/src/configsys.c
@@ -76,6 +76,8 @@ static cfg_opt_t config_opts[] = {
     CFG_INT("auto_hide_time", 2000, CFGF_NONE),
     CFG_INT("on_last_terminal_exit", 0, CFGF_NONE),
     CFG_INT("palette_scheme", 0, CFGF_NONE),
+    CFG_INT("non_focus_pull_up_behaviour", 0, CFGF_NONE),
+
     /* The default monitor number is 0 */
     CFG_INT("show_on_monitor_number", 0, CFGF_NONE),
     /* The length of a tab title */

--- a/src/key_grabber.c
+++ b/src/key_grabber.c
@@ -186,7 +186,7 @@ void pull (struct tilda_window_ *tw, enum pull_state state)
 
     gint i;
 
-    if (tw->current_state == DOWN && !tw->focus_loss_on_keypress && !gtk_window_is_active(GTK_WINDOW(tw->window))) {
+    if (!tw->hide_non_focused && tw->current_state == DOWN && !tw->focus_loss_on_keypress && !gtk_window_is_active(GTK_WINDOW(tw->window))) {
         /**
         * See tilda_window.c in focus_out_event_cb for an explanation about focus_loss_on_keypress
         * This case will only focus tilda but it does not actually pull the window up.

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -546,6 +546,13 @@ gboolean tilda_window_init (const gchar *config_file, const gint instance, tilda
     tw->disable_auto_hide = FALSE;
     tw->focus_loss_on_keypress = FALSE;
 
+    if(1 == config_getint("non_focus_pull_up_behaviour")) {
+        tw->hide_non_focused = TRUE;
+    }
+    else {
+        tw->hide_non_focused = FALSE;
+    }
+
     tw->fullscreen = FALSE;
 
     /* Set up all window properties */

--- a/src/tilda_window.h
+++ b/src/tilda_window.h
@@ -55,6 +55,9 @@ struct tilda_window_
     /* Should Tilda hide itself when mouse leaves it? */
     gboolean auto_hide_on_mouse_leave;
 
+    /* Should Tilda hide itself even if not focused */
+    gboolean hide_non_focused;
+
 	gboolean fullscreen;
 
     /* This field MUST be set before calling pull()! */

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -864,6 +864,26 @@ static void check_allow_bold_text_toggled_cb (GtkWidget *w)
     }
 }
 
+static void combo_non_focus_pull_up_behaviour_cb (GtkWidget *w)
+{
+    const gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
+
+    if (status < 0 || status > 1) {
+        DEBUG_ERROR ("Non-focus pull up behaviour invalid");
+        g_printerr (_("Invalid non-focus pull up behaviour, ignoring\n"));
+        return;
+    }
+
+    if(1 == status) {
+        tw->hide_non_focused = TRUE;
+    }
+    else {
+        tw->hide_non_focused = FALSE;
+    }
+
+    config_setint ("non_focus_pull_up_behaviour", status);
+}
+
 static void combo_tab_pos_changed_cb (GtkWidget *w)
 {
     const gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
@@ -1962,6 +1982,7 @@ static void set_wizard_state_from_config () {
     CHECK_BUTTON ("check_start_tilda_hidden", "hidden");
     CHECK_BUTTON ("check_show_notebook_border", "notebook_border");
     CHECK_BUTTON ("check_enable_double_buffering", "double_buffer");
+    COMBO_BOX ("combo_non_focus_pull_up_behaviour", "non_focus_pull_up_behaviour");
 
     CHECK_BUTTON ("check_terminal_bell", "bell");
     CHECK_BUTTON ("check_cursor_blinks", "blinks");
@@ -2100,6 +2121,7 @@ static void connect_wizard_signals ()
     CONNECT_SIGNAL ("check_always_on_top","toggled",check_always_on_top_toggled_cb);
     CONNECT_SIGNAL ("check_start_tilda_hidden","toggled",check_start_tilda_hidden_toggled_cb);
     CONNECT_SIGNAL ("check_enable_double_buffering","toggled",check_enable_double_buffering_toggled_cb);
+    CONNECT_SIGNAL ("combo_non_focus_pull_up_behaviour","changed",combo_non_focus_pull_up_behaviour_cb);
 
     CONNECT_SIGNAL ("check_terminal_bell","toggled",check_terminal_bell_toggled_cb);
     CONNECT_SIGNAL ("check_cursor_blinks","toggled",check_cursor_blinks_toggled_cb);

--- a/tilda.glade
+++ b/tilda.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.16.1 -->
+<!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkAdjustment" id="adjustment1">
@@ -93,6 +93,20 @@
       </row>
       <row>
         <col id="0" translatable="yes">Right</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="model10">
+    <columns>
+      <!-- column-name gchararray -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Focus Terminal</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Hide Terminal</col>
       </row>
     </data>
   </object>
@@ -425,9 +439,44 @@
                               <packing>
                                 <property name="left_attach">0</property>
                                 <property name="top_attach">0</property>
-                                <property name="width">1</property>
-                                <property name="height">1</property>
                               </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="lbl_non_focus_pull_up_behaviour">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">1</property>
+                                <property name="label" translatable="yes">Non-focus Pull Up Behaviour:</property>
+                                <property name="ellipsize">end</property>
+                                <property name="width_chars">0</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="combo_non_focus_pull_up_behaviour">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="model">model10</property>
+                                <child>
+                                  <object class="GtkCellRendererText" id="renderer11"/>
+                                  <attributes>
+                                    <attribute name="text">0</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
                             </child>
                           </object>
                         </child>


### PR DESCRIPTION
- Focus Terminal: put focus back on the terminal window instead of hiding it.
- Hide Terminal: hide terminal window instead of putting the focus back to it.

Note:
The new behavior of pull-up was interrupting my usual workflow for two reasons.
1. When I have Tilda open in workspace A and I'm on workspace B, hitting pull-up key twice used to bring the Tilda to current workspace. But now it switch me to workspace A because of the Tilda window being focused.
2. I used to launch GUI application from the command like (i.e gvim, gitk, etc.) and if I feel I need space for the application (in a tiling WM) I hit the pull-up key to hide the Tilda window while in the newly launched application. New behavior takes the focus out of my working application which is not what I need.

I understand that other may prefer the new new behavior, therefor I made this patch so that user can choose which behavior they would like Tilda to have.
