### PR TITLE
Option to hide tab bar and border while multiple tabs are open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ src/Makefile.in
 src/key_converter.c
 src/tilda
 stamp-h1
+tilda.glade~
 tilda-config.h
 tilda-config.h.in
 tilda-config.h.in~

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -96,14 +96,22 @@ void tilda_window_close_current_tab (tilda_window *tw)
 
 gint tilda_window_set_tab_position (tilda_window *tw, enum notebook_tab_positions pos)
 {
-    const gint gtk_pos[] = { GTK_POS_TOP, GTK_POS_BOTTOM, GTK_POS_LEFT, GTK_POS_RIGHT };
+    const gint gtk_pos[] = { -1, GTK_POS_TOP, GTK_POS_BOTTOM, GTK_POS_LEFT, GTK_POS_RIGHT };
 
-    if ((pos < 0) || (pos > 3)) {
+    if ((pos < 0) || (pos > 4)) {
         g_printerr (_("You have a bad tab_pos in your configuration file\n"));
         pos = NB_TOP;
     }
 
-    gtk_notebook_set_tab_pos (GTK_NOTEBOOK (tw->notebook), gtk_pos[pos]);
+    if(-1 == gtk_pos[pos]) {
+        gtk_notebook_set_show_tabs (GTK_NOTEBOOK(tw->notebook), FALSE);
+    }
+    else {
+        gtk_notebook_set_tab_pos (GTK_NOTEBOOK (tw->notebook), gtk_pos[pos]);
+
+        if (gtk_notebook_get_n_pages (GTK_NOTEBOOK (tw->notebook)) > 1)
+            gtk_notebook_set_show_tabs (GTK_NOTEBOOK(tw->notebook), TRUE);
+    }
 
     return 0;
 }
@@ -690,8 +698,10 @@ gint tilda_window_add_tab (tilda_window *tw)
     gtk_notebook_set_current_page (GTK_NOTEBOOK(tw->notebook), index);
     gtk_notebook_set_tab_reorderable (GTK_NOTEBOOK(tw->notebook), tt->hbox, TRUE);
 
-    /* We should show the tabs if there are more than one tab in the notebook */
-    if (gtk_notebook_get_n_pages (GTK_NOTEBOOK (tw->notebook)) > 1)
+    /* We should show the tabs if there are more than one tab in the notebook,
+     * and tab position is not set to hidden (tab_pos = 0) */
+    if (gtk_notebook_get_n_pages (GTK_NOTEBOOK (tw->notebook)) > 1 &&
+            config_getint("tab_pos") > 0)
         gtk_notebook_set_show_tabs (GTK_NOTEBOOK (tw->notebook), TRUE);
 
     /* Add to GList list of tilda_term structures in tilda_window structure */

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -867,7 +867,8 @@ static void check_allow_bold_text_toggled_cb (GtkWidget *w)
 static void combo_tab_pos_changed_cb (GtkWidget *w)
 {
     const gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
-    const gint positions[] = { GTK_POS_TOP,
+    const gint positions[] = { -1,
+                             GTK_POS_TOP,
                              GTK_POS_BOTTOM,
                              GTK_POS_LEFT,
                              GTK_POS_RIGHT };
@@ -879,7 +880,14 @@ static void combo_tab_pos_changed_cb (GtkWidget *w)
     }
 
     config_setint ("tab_pos", status);
-    gtk_notebook_set_tab_pos (GTK_NOTEBOOK(tw->notebook), positions[status]);
+
+    if(-1 == positions[status]) {
+        gtk_notebook_set_show_tabs (GTK_NOTEBOOK(tw->notebook), FALSE);
+    }
+    else {
+        gtk_notebook_set_show_tabs (GTK_NOTEBOOK(tw->notebook), TRUE);
+        gtk_notebook_set_tab_pos (GTK_NOTEBOOK(tw->notebook), positions[status]);
+    }
 }
 
 static void button_font_font_set_cb (GtkWidget *w)

--- a/tilda.glade
+++ b/tilda.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.16.1 -->
+<!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkAdjustment" id="adjustment1">
@@ -82,6 +82,9 @@
       <column type="gchararray"/>
     </columns>
     <data>
+      <row>
+        <col id="0" translatable="yes">Hidden</col>
+      </row>
       <row>
         <col id="0" translatable="yes">Top</col>
       </row>


### PR DESCRIPTION
- Added an extra option "Hidden" to "Position of Tabs"
- Effect will apply on option selection, opening new tab and on launch
- This should also solve issue #81
