### PR TITLE
Allow "NULL" keybinding in config file

### DIFF
--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -442,6 +442,8 @@ static gint cpaste (tilda_window *tw)
 /* Tie a single keyboard shortcut to a callback function */
 static gint tilda_add_config_accelerator(const gchar* key, GCallback callback_func, tilda_window *tw)
 {
+    //Don't try to bind Blank Strings
+    if (strcmp(key, "NULL") ==0) return 0; 
     guint accel_key;
     GdkModifierType accel_mods;
     GClosure *temp;

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -313,6 +313,9 @@ static gboolean validate_pulldown_keybinding(const gchar* accel, const GtkWidget
 
 static gboolean validate_keybinding(const gchar* accel, const GtkWidget* wizard_window, const gchar* message)
 {
+    //Skip validation and return True for blank string
+    if (strcmp(accel, "NULL") == 0) return TRUE; 
+
     guint accel_key;
     GdkModifierType accel_mods;
 


### PR DESCRIPTION
Tiny addition to allow hot-keys to be unbound #110. 
I used "NULL" instead of a blank_string since config overwrites blanks with default values. If this is used often enough a button could be added next to `cancel` in the key-binding dialog for `unbind` or `null` (currently NULL can only be specified via. config file). 