### PR TITLE
Prevent repetitive PULL_TOGGLE when autohide option is used

### DIFF
--- a/src/key_grabber.c
+++ b/src/key_grabber.c
@@ -193,6 +193,11 @@ void pull (struct tilda_window_ *tw, enum pull_state state, gboolean force_hide)
             && !force_hide
             && !tw->hide_non_focused;
 
+    if (state == PULL_TOGGLE && tw->last_action == PULL_UP && g_get_monotonic_time() - tw->last_action_time < 150000) {
+        /* this is to prevent crazy toggling, with 50ms prevention time */
+        return;
+    }
+
     if (tw->current_state == DOWN && needsFocus) {
         /**
         * See tilda_window.c in focus_out_event_cb for an explanation about focus_loss_on_keypress
@@ -268,6 +273,8 @@ void pull (struct tilda_window_ *tw, enum pull_state state, gboolean force_hide)
         debug_printf ("pull(): MOVED UP\n");
         tw->current_state = UP;
     }
+    tw->last_action = state;
+    tw->last_action_time = g_get_monotonic_time();
 }
 
 static void onKeybindingPull (G_GNUC_UNUSED const char *keystring, gpointer user_data)

--- a/src/key_grabber.h
+++ b/src/key_grabber.h
@@ -20,7 +20,6 @@
 
 G_BEGIN_DECLS
 
-enum pull_state { PULL_UP, PULL_DOWN, PULL_TOGGLE };
 void pull (struct tilda_window_ *tw, enum pull_state state, gboolean force_hide);
 
 extern void generate_animation_positions (tilda_window *tw);

--- a/src/tilda_window.h
+++ b/src/tilda_window.h
@@ -24,6 +24,8 @@
 
 G_BEGIN_DECLS
 
+enum pull_state { PULL_UP, PULL_DOWN, PULL_TOGGLE };
+
 typedef struct tilda_window_ tilda_window;
 
 struct tilda_window_
@@ -62,6 +64,10 @@ struct tilda_window_
     /* This field MUST be set before calling pull()! */
     enum tilda_positions { UP, DOWN } current_state;
     gboolean focus_loss_on_keypress;
+
+    /* .. */
+    enum pull_state last_action;
+    gint64 last_action_time;
 };
 
 enum notebook_tab_positions { NB_TOP, NB_BOTTOM, NB_LEFT, NB_RIGHT, NB_HIDDEN };


### PR DESCRIPTION
I had a problem hiding tilda with toggle hot key when `auto_hide_on_focus_lost` was enabled. Autohide was working perfectly. But if I try to hide with the toggle key, it was getting back instantly. When I compiled it with the debug mode, the following output happened (in an instant way) when I tried toggle hiding the window.

```
tilda_window.c: FUNCTION ENTERED: focus_out_event_cb
tilda_window.c: FUNCTION ENTERED: start_auto_hide_tick
key_grabber.c: FUNCTION ENTERED: pull
key_grabber.c: FUNCTION ENTERED: onKeybindingPull
key_grabber.c: FUNCTION ENTERED: pull
tilda_window.c: FUNCTION ENTERED: focus_term
key_grabber.c: FUNCTION ENTERED: tilda_window_set_active
```

The main reason is a false alarm of losing focus when toggle key is used. So it quickly does two things in order; 1) Autohide (lost focus)  2) Toggle, which is reverting it again.

My solution here might be an ugly workaround, not sure. I've added a small timeout (150ms) for a PULL_TOGGLE action to be able to happen after a PULL_UP action.

Had to move `enum pull_state` into `tilda_window.h`, please relocate if you dislike it there.

And thanks for nice piece for software :)
