### PR TITLE
Transparency fix

### DIFF
--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -572,6 +572,8 @@ gboolean tilda_window_init (const gchar *config_file, const gint instance, tilda
     tilda_window_set_icon (tw, g_build_filename (DATADIR, "pixmaps", "tilda.png", NULL));
     tilda_window_setup_alpha_mode (tw);
 
+    gtk_widget_set_app_paintable(GTK_WIDGET(tw->window), TRUE);
+
     /* Add keyboard accelerators */
     tw->accel_group = NULL; /* We can redefine the accelerator group from the wizard; this shows that it's our first time defining it. */
     tilda_window_setup_keyboard_accelerators (tw);


### PR DESCRIPTION
Added gtk_widget_set_app_paintable to make transparency setting work on my GNOME Shell 3.10.x (GNOME Ubuntu 14.04).