### PR TITLE
Add suport for using Tilda as a desktop (aka transparent wallpaper) term...

### DIFF
--- a/src/configsys.c
+++ b/src/configsys.c
@@ -145,6 +145,7 @@ static cfg_opt_t config_opts[] = {
     CFG_BOOL("pinned", TRUE, CFGF_NONE),
     CFG_BOOL("animation", FALSE, CFGF_NONE),
     CFG_BOOL("hidden", FALSE, CFGF_NONE),
+    CFG_BOOL("set_as_desktop", FALSE, CFGF_NONE),
     CFG_BOOL("centered_horizontally", FALSE, CFGF_NONE),
     CFG_BOOL("centered_vertically", FALSE, CFGF_NONE),
     CFG_BOOL("enable_transparency", FALSE, CFGF_NONE),

--- a/src/tilda.ui
+++ b/src/tilda.ui
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
+  <!-- interface-requires gtk+ 3.0 -->
   <object class="GtkAdjustment" id="adjustment1">
     <property name="upper">100</property>
     <property name="step_increment">1</property>
@@ -298,9 +297,11 @@
             <child>
               <object class="GtkButton" id="button_wizard_close">
                 <property name="label">gtk-close</property>
+                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="receives_default">False</property>
+                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
                 <signal name="clicked" handler="button_wizard_close_clicked_cb" swapped="no"/>
               </object>
@@ -353,9 +354,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_enable_double_buffering">
                                 <property name="label" translatable="yes">Enable Double Buffering</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -369,9 +372,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_start_tilda_hidden">
                                 <property name="label" translatable="yes">Start Tilda hidden</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -385,9 +390,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_always_on_top">
                                 <property name="label" translatable="yes">Always on top</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -401,9 +408,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_display_on_all_workspaces">
                                 <property name="label" translatable="yes">Display on all workspaces</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -417,9 +426,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_do_not_show_in_taskbar">
                                 <property name="label" translatable="yes">Do not show in taskbar</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -433,15 +444,19 @@
                             <child>
                               <object class="GtkCheckButton" id="check_show_notebook_border">
                                 <property name="label" translatable="yes">Show Notebook Border</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
                               <packing>
                                 <property name="left_attach">0</property>
                                 <property name="top_attach">0</property>
+                                <property name="width">1</property>
+                                <property name="height">1</property>
                               </packing>
                             </child>
                             <child>
@@ -456,6 +471,8 @@
                               <packing>
                                 <property name="left_attach">0</property>
                                 <property name="top_attach">4</property>
+                                <property name="width">1</property>
+                                <property name="height">1</property>
                               </packing>
                             </child>
                             <child>
@@ -473,13 +490,30 @@
                               <packing>
                                 <property name="left_attach">1</property>
                                 <property name="top_attach">4</property>
+                                <property name="width">1</property>
+                                <property name="height">1</property>
                               </packing>
                             </child>
                             <child>
                               <placeholder/>
                             </child>
                             <child>
-                              <placeholder/>
+                              <object class="GtkCheckButton" id="check_set_as_desktop">
+                                <property name="label" translatable="yes">Set as Desktop window</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="xalign">0</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">3</property>
+                                <property name="width">1</property>
+                                <property name="height">1</property>
+                              </packing>
                             </child>
                           </object>
                         </child>
@@ -529,9 +563,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_cursor_blinks">
                                 <property name="label" translatable="yes">Cursor Blinks</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -545,9 +581,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_terminal_bell">
                                 <property name="label" translatable="yes">Audible Terminal Bell</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -606,9 +644,11 @@
                             <property name="column_homogeneous">True</property>
                             <child>
                               <object class="GtkFontButton" id="button_font">
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">True</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="font">Sans 12</property>
                                 <property name="preview_text"/>
                                 <property name="show_preview_entry">False</property>
@@ -623,9 +663,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_enable_antialiasing">
                                 <property name="label" translatable="yes">Enable Antialiasing</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -639,9 +681,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_allow_bold_text">
                                 <property name="label" translatable="yes">Allow Bold Text</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -761,9 +805,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_auto_hide_on_mouse_leave">
                                 <property name="label" translatable="yes">Hide Tilda when mouse leaves it</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -792,9 +838,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_auto_hide_on_focus_lost">
                                 <property name="label" translatable="yes">Hide when Tilda loses focus</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -1160,9 +1208,11 @@
                                 <child>
                                   <object class="GtkCheckButton" id="check_title_max_length">
                                     <property name="label" translatable="yes">Limit maximum length of tab title:</property>
+                                    <property name="use_action_appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="receives_default">False</property>
+                                    <property name="use_action_appearance">False</property>
                                     <property name="xalign">1</property>
                                     <property name="draw_indicator">True</property>
                                   </object>
@@ -1228,9 +1278,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_run_custom_command">
                                 <property name="label" translatable="yes">Run a custom command instead of the shell</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -1590,9 +1642,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_centered_horizontally">
                                 <property name="label" translatable="yes">Centered Horizontally</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
@@ -1608,9 +1662,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_centered_vertically">
                                 <property name="label" translatable="yes">Centered Vertically</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
@@ -1732,9 +1788,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_enable_transparency">
                                 <property name="label" translatable="yes">Enable Transparency</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -1776,9 +1834,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_animated_pulldown">
                                 <property name="label" translatable="yes">Animated Pulldown</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -1793,9 +1853,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_use_image_for_background">
                                 <property name="label" translatable="yes">Use Image for Background</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -2122,9 +2184,11 @@
                             </child>
                             <child>
                               <object class="GtkColorButton" id="colorbutton_text">
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="color">#000000000000</property>
                               </object>
                               <packing>
@@ -2138,9 +2202,11 @@
                             </child>
                             <child>
                               <object class="GtkColorButton" id="colorbutton_back">
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="color">#000000000000</property>
                               </object>
                               <packing>
@@ -2249,10 +2315,12 @@
                                     <property name="n_columns">8</property>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_14">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 15</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">6</property>
@@ -2265,10 +2333,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_6">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 7</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">6</property>
@@ -2279,10 +2349,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_13">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 14</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">5</property>
@@ -2295,10 +2367,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_15">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 16</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">7</property>
@@ -2311,10 +2385,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_12">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 13</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">4</property>
@@ -2327,10 +2403,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_10">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 11</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">2</property>
@@ -2343,10 +2421,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_11">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 12</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">3</property>
@@ -2359,10 +2439,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_9">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 10</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">1</property>
@@ -2375,10 +2457,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_8">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 9</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="top_attach">1</property>
@@ -2389,10 +2473,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_7">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 8</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">7</property>
@@ -2403,10 +2489,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_5">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 6</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">5</property>
@@ -2417,10 +2505,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_4">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 5</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">4</property>
@@ -2431,10 +2521,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_3">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 4</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">3</property>
@@ -2445,10 +2537,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_2">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 3</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">2</property>
@@ -2459,10 +2553,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_1">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 2</property>
+                                        <property name="use_action_appearance">False</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">1</property>
@@ -2473,10 +2569,12 @@
                                     </child>
                                     <child>
                                       <object class="GtkColorButton" id="colorbutton_palette_0">
+                                        <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text">Choose color 1</property>
+                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                       </object>
                                       <packing>
@@ -2667,10 +2765,12 @@
                             <child>
                               <object class="GtkCheckButton" id="check_infinite_scrollback">
                                 <property name="label" translatable="yes">Limit scrollback to:</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
                                 <property name="tooltip_text" translatable="yes">Unselect for unlimited scrollback.</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -2684,9 +2784,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_scroll_on_output">
                                 <property name="label" translatable="yes">Scroll on Output</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -2701,9 +2803,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_scroll_on_keystroke">
                                 <property name="label" translatable="yes">Scroll on Keystroke</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -2718,9 +2822,11 @@
                             <child>
                               <object class="GtkCheckButton" id="check_scroll_background">
                                 <property name="label" translatable="yes">Scroll Background</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="xalign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
@@ -2920,9 +3026,11 @@
                             <child>
                               <object class="GtkButton" id="button_reset_compatibility_options">
                                 <property name="label" translatable="yes">_Reset Compatibility Options to Defaults</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="use_underline">True</property>
                               </object>
                             </child>
@@ -2985,10 +3093,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_paste">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3025,10 +3135,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_nexttab">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3063,10 +3175,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_quit">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3101,10 +3215,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_addtab">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3140,10 +3256,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_gototab10">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3180,10 +3298,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_gototab5">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3218,10 +3338,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_gototab4">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3256,10 +3378,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_gototab3">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3294,10 +3418,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_gototab2">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3332,10 +3458,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_gototab1">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3370,10 +3498,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_prevtab">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3410,10 +3540,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_closetab">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3450,10 +3582,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_copy">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3488,10 +3622,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_pulldown">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3524,10 +3660,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_gototab6">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3564,10 +3702,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_gototab7">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3604,10 +3744,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_gototab8">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3644,10 +3786,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_gototab9">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3684,10 +3828,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_movetableft">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3722,10 +3868,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_movetabright">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>
@@ -3762,10 +3910,12 @@
                         <child>
                           <object class="GtkButton" id="button_keybinding_fullscreen">
                             <property name="label" translatable="yes"> </property>
+                            <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">True</property>
                             <property name="margin_right">2</property>
+                            <property name="use_action_appearance">False</property>
                           </object>
                         </child>
                       </object>

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -541,6 +541,7 @@ gboolean tilda_window_init (const gchar *config_file, const gint instance, tilda
     /* Create the main window */
     tw->window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
 
+
     /* Generic timer resolution */
     tw->timer_resolution = config_getint("timer_resolution");
 
@@ -565,6 +566,8 @@ gboolean tilda_window_init (const gchar *config_file, const gint instance, tilda
     if (config_getbool ("pinned"))
         gtk_window_stick (GTK_WINDOW(tw->window));
 
+    if(config_getbool ("set_as_desktop"))
+        gtk_window_set_type_hint(GTK_WINDOW(tw->window), GDK_WINDOW_TYPE_HINT_DESKTOP);
     gtk_window_set_skip_taskbar_hint (GTK_WINDOW(tw->window), config_getbool ("notaskbar"));
     gtk_window_set_keep_above (GTK_WINDOW(tw->window), config_getbool ("above"));
     gtk_window_set_decorated (GTK_WINDOW(tw->window), FALSE);

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -732,6 +732,18 @@ static void check_display_on_all_workspaces_toggled_cb (GtkWidget *w)
         gtk_window_unstick (GTK_WINDOW (tw->window));
 }
 
+static void check_set_as_desktop_toggled_cb (GtkWidget *w)
+{
+    const gboolean status = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(w));
+
+    config_setbool ("set_as_desktop", status);
+
+    if (status)
+        gtk_window_stick (GTK_WINDOW (tw->window));
+    else
+        gtk_window_unstick (GTK_WINDOW (tw->window));
+}
+
 static void check_do_not_show_in_taskbar_toggled_cb (GtkWidget *w)
 {
     const gboolean status = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(w));
@@ -1984,6 +1996,7 @@ static void set_wizard_state_from_config () {
 
     /* General Tab */
     CHECK_BUTTON ("check_display_on_all_workspaces", "pinned");
+    CHECK_BUTTON ("check_set_as_desktop", "set_as_desktop");
     CHECK_BUTTON ("check_always_on_top", "above");
     CHECK_BUTTON ("check_do_not_show_in_taskbar", "notaskbar");
     CHECK_BUTTON ("check_start_tilda_hidden", "hidden");
@@ -2123,6 +2136,7 @@ static void connect_wizard_signals ()
 
     /* General Tab */
     CONNECT_SIGNAL ("check_display_on_all_workspaces","toggled",check_display_on_all_workspaces_toggled_cb);
+    CONNECT_SIGNAL ("check_set_as_desktop","toggled",check_set_as_desktop_toggled_cb);
     CONNECT_SIGNAL ("check_do_not_show_in_taskbar","toggled",check_do_not_show_in_taskbar_toggled_cb);
     CONNECT_SIGNAL ("check_show_notebook_border","toggled",check_show_notebook_border_toggled_cb);
     CONNECT_SIGNAL ("check_always_on_top","toggled",check_always_on_top_toggled_cb);


### PR DESCRIPTION
...inal.

Set the window hint allowing us to persist across go-to-desktop functionality
invocations on all ICCCM/EWMH compliant window managers. Configurable setting,
defaults to no. Support for it added to the wizard as well.

Goes with enhancement request in issue #123 