### PR TITLE
add options to set cursor type and color

### DIFF
--- a/src/configsys.c
+++ b/src/configsys.c
@@ -73,8 +73,6 @@ static cfg_opt_t config_opts[] = {
     CFG_STR("decrease_font_size_key", "<Control>minus", CFGF_NONE),
     CFG_STR("normalize_font_size_key", "<Control>0", CFGF_NONE),
     
-
-    
     /* ints */
     CFG_INT("lines", 100, CFGF_NONE),
     CFG_INT("max_width", 600, CFGF_NONE),

--- a/src/configsys.c
+++ b/src/configsys.c
@@ -72,7 +72,9 @@ static cfg_opt_t config_opts[] = {
     CFG_STR("increase_font_size_key", "<Control>equal", CFGF_NONE),
     CFG_STR("decrease_font_size_key", "<Control>minus", CFGF_NONE),
     CFG_STR("normalize_font_size_key", "<Control>0", CFGF_NONE),
+    
 
+    
     /* ints */
     CFG_INT("lines", 100, CFGF_NONE),
     CFG_INT("max_width", 600, CFGF_NONE),
@@ -95,6 +97,7 @@ static cfg_opt_t config_opts[] = {
     CFG_INT("on_last_terminal_exit", 0, CFGF_NONE),
     CFG_INT("palette_scheme", 0, CFGF_NONE),
     CFG_INT("non_focus_pull_up_behaviour", 0, CFGF_NONE),
+    CFG_INT("cursor_type", 0, CFGF_NONE),
 
     /* The default monitor number is 0 */
     CFG_INT("show_on_monitor_number", 0, CFGF_NONE),
@@ -129,6 +132,10 @@ static cfg_opt_t config_opts[] = {
     CFG_INT("text_red", 0xffff, CFGF_NONE),
     CFG_INT("text_green", 0xffff, CFGF_NONE),
     CFG_INT("text_blue", 0xffff, CFGF_NONE),
+    CFG_INT("cursor_red", 0xffff, CFGF_NONE),
+    CFG_INT("cursor_green", 0xffff, CFGF_NONE),
+    CFG_INT("cursor_blue", 0xffff, CFGF_NONE),
+ 
 
     /* booleans */
     CFG_BOOL("scroll_history_infinite", FALSE, CFGF_NONE),

--- a/src/configsys.c
+++ b/src/configsys.c
@@ -97,7 +97,7 @@ static cfg_opt_t config_opts[] = {
     CFG_INT("on_last_terminal_exit", 0, CFGF_NONE),
     CFG_INT("palette_scheme", 0, CFGF_NONE),
     CFG_INT("non_focus_pull_up_behaviour", 0, CFGF_NONE),
-    CFG_INT("cursor_type", 0, CFGF_NONE),
+    CFG_INT("cursor_shape", 0, CFGF_NONE),
 
     /* The default monitor number is 0 */
     CFG_INT("show_on_monitor_number", 0, CFGF_NONE),

--- a/src/tilda.ui
+++ b/src/tilda.ui
@@ -594,6 +594,22 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkLabel" id="label_vte_cursor_shape">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">1</property>
+                                <property name="label" translatable="yes">Cursor Shape: </property>
+                                <property name="ellipsize">end</property>
+                                <property name="width_chars">0</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">2</property>
+                                <property name="top_attach">0</property>
+                                <property name="width">1</property>
+                                <property name="height">1</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkComboBox" id="vte_cursor_shape">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -606,7 +622,7 @@
                                 </child>
                               </object>
                               <packing>
-                                <property name="left_attach">2</property>
+                                <property name="left_attach">3</property>
                                 <property name="top_attach">0</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>

--- a/src/tilda.ui
+++ b/src/tilda.ui
@@ -99,6 +99,23 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="model11">
+    <columns>
+      <!-- column-name gchararray -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Block Cursor</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Underline Cursor</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">IBeam Cursor</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkListStore" id="model10">
     <columns>
       <!-- column-name gchararray -->
@@ -479,7 +496,7 @@
                                 <property name="left_attach">1</property>
                                 <property name="top_attach">4</property>
                               </packing>
-                            </child>
+                            </child> 
                             <child>
                               <object class="GtkCheckButton" id="check_start_fullscreen">
                                 <property name="label" translatable="yes">Start in fullscreen</property>
@@ -571,6 +588,25 @@
                               </object>
                               <packing>
                                 <property name="left_attach">0</property>
+                                <property name="top_attach">0</property>
+                                <property name="width">1</property>
+                                <property name="height">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="vte_cursor_type">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="model">model11</property>
+                                <child>
+                                  <object class="GtkCellRendererText" id="renderer17"/>
+                                  <attributes>
+                                    <attribute name="text">0</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">2</property>
                                 <property name="top_attach">0</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
@@ -2150,6 +2186,34 @@
                             <property name="height">1</property>
                           </packing>
                         </child>
+                        <child>
+                              <object class="GtkLabel" id="label_cursor_color">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">1</property>
+                                <property name="label" translatable="yes">Cursor Color</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">4</property>
+                                <property name="width">1</property>
+                                <property name="height">1</property>
+                              </packing>
+                        </child>
+                        <child>
+                              <object class="GtkColorButton" id="colorbutton_cursor">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="rgba">rgb(0,0,0)</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">4</property>
+                                <property name="width">1</property>
+                                <property name="height">1</property>
+                              </packing>
+                             </child>
                         <child>
                           <object class="GtkColorButton" id="colorbutton_text">
                             <property name="visible">True</property>

--- a/src/tilda.ui
+++ b/src/tilda.ui
@@ -109,10 +109,10 @@
         <col id="0" translatable="yes">Block Cursor</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Underline Cursor</col>
+        <col id="0" translatable="yes">IBeam Cursor</col>
       </row>
       <row>
-        <col id="0" translatable="yes">IBeam Cursor</col>
+        <col id="0" translatable="yes">Underline Cursor</col>
       </row>
     </data>
   </object>
@@ -594,7 +594,7 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkComboBox" id="vte_cursor_type">
+                              <object class="GtkComboBox" id="vte_cursor_shape">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="model">model11</property>

--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -557,7 +557,8 @@ static gint tilda_term_config_defaults (tilda_term *tt)
     GdkRGBA fg, bg, cc;
     gchar* word_chars;
     gint i;
-
+    gint cursor_shape; 
+    
     /** Colors & Palette **/
     bg.red   =    GUINT16_TO_FLOAT(config_getint ("back_red"));
     bg.green =    GUINT16_TO_FLOAT(config_getint ("back_green"));
@@ -592,20 +593,11 @@ static gint tilda_term_config_defaults (tilda_term *tt)
             (config_getbool ("blinks"))?VTE_CURSOR_BLINK_ON:VTE_CURSOR_BLINK_OFF);
     vte_terminal_set_color_cursor_rgba (VTE_TERMINAL(tt->vte_term), &cc);
     
-    switch(config_getint("cursor_type")) {
-        case 0: 
-            vte_terminal_set_cursor_shape(VTE_TERMINAL(tt->vte_term), VTE_CURSOR_SHAPE_BLOCK);
-        case 1: 
-            vte_terminal_set_cursor_shape(VTE_TERMINAL(tt->vte_term), VTE_CURSOR_SHAPE_IBEAM);
-            break;  
-        case 2: 
-            vte_terminal_set_cursor_shape(VTE_TERMINAL(tt->vte_term), VTE_CURSOR_SHAPE_UNDERLINE);
-            break;
-        default: 
-            config_setint("cursor_type", 0);
-            vte_terminal_set_cursor_shape(VTE_TERMINAL(tt->vte_term), VTE_CURSOR_SHAPE_BLOCK);
-            break;
+    if ((cursor_shape = config_getint("cursor_shape")) < 0 || cursor_shape > 2) {
+        config_setint("cursor_shape", 0);
+        cursor_shape = 0;
     }
+    vte_terminal_set_cursor_shape(VTE_TERMINAL(tt->vte_term), (VteTerminalCursorShape)cursor_shape);
     
     /** Scrolling **/
     vte_terminal_set_scroll_background (VTE_TERMINAL(tt->vte_term), config_getbool ("scroll_background"));

--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -554,7 +554,7 @@ static gint tilda_term_config_defaults (tilda_term *tt)
     DEBUG_ASSERT (tt != NULL);
 
     gdouble transparency_level = 0.0;
-    GdkRGBA fg, bg;
+    GdkRGBA fg, bg, cc;
     gchar* word_chars;
     gint i;
 
@@ -569,6 +569,11 @@ static gint tilda_term_config_defaults (tilda_term *tt)
     fg.blue  =    GUINT16_TO_FLOAT(config_getint ("text_blue"));
     fg.alpha =    1.0;
 
+    cc.red   =    GUINT16_TO_FLOAT(config_getint ("cursor_red"));
+    cc.green =    GUINT16_TO_FLOAT(config_getint ("cursor_green"));
+    cc.blue  =    GUINT16_TO_FLOAT(config_getint ("cursor_blue"));
+    cc.alpha = 1.0; 
+    
     for(i = 0;i < TERMINAL_PALETTE_SIZE; i++) {
         current_palette[i].red   = GUINT16_TO_FLOAT(config_getnint ("palette", i*3));
         current_palette[i].green = GUINT16_TO_FLOAT(config_getnint ("palette", i*3+1));
@@ -585,7 +590,23 @@ static gint tilda_term_config_defaults (tilda_term *tt)
     /** Cursor **/
     vte_terminal_set_cursor_blink_mode (VTE_TERMINAL(tt->vte_term),
             (config_getbool ("blinks"))?VTE_CURSOR_BLINK_ON:VTE_CURSOR_BLINK_OFF);
-
+    vte_terminal_set_color_cursor_rgba (VTE_TERMINAL(tt->vte_term), &cc);
+    
+    switch(config_getint("cursor_type")) {
+        case 0: 
+            vte_terminal_set_cursor_shape(VTE_TERMINAL(tt->vte_term), VTE_CURSOR_SHAPE_BLOCK);
+        case 1: 
+            vte_terminal_set_cursor_shape(VTE_TERMINAL(tt->vte_term), VTE_CURSOR_SHAPE_IBEAM);
+            break;  
+        case 2: 
+            vte_terminal_set_cursor_shape(VTE_TERMINAL(tt->vte_term), VTE_CURSOR_SHAPE_UNDERLINE);
+            break;
+        default: 
+            config_setint("cursor_type", 0);
+            vte_terminal_set_cursor_shape(VTE_TERMINAL(tt->vte_term), VTE_CURSOR_SHAPE_BLOCK);
+            break;
+    }
+    
     /** Scrolling **/
     vte_terminal_set_scroll_background (VTE_TERMINAL(tt->vte_term), config_getbool ("scroll_background"));
     vte_terminal_set_scroll_on_output (VTE_TERMINAL(tt->vte_term), config_getbool ("scroll_on_output"));

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -897,31 +897,22 @@ static void check_allow_bold_text_toggled_cb (GtkWidget *w)
     }
 }
 
-static void vte_cursor_type_cb (GtkWidget *w)
+static void vte_cursor_shape_cb (GtkWidget *w)
 {
-    VteTerminalCursorShape cursor_shape;
-    gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
-
-    switch (status) {
-        case 1:
-            cursor_shape = VTE_CURSOR_SHAPE_IBEAM;
-            break;
-        case 2:
-            cursor_shape = VTE_CURSOR_SHAPE_UNDERLINE;
-            break;
-        default: 
-            cursor_shape = VTE_CURSOR_SHAPE_BLOCK;
-            status=0;
-            break;
-    }
-    
     gint i;
     tilda_term *tt;
-    config_setint("cursor_type", status);
+    gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
+    
+    if (status < 0 || status > 2) {
+        DEBUG_ERROR ("Invalid Cursor Type");
+        g_printerr (_("Invalid Cursor Type, reseting to default\n"));
+        status = 0;
+    }
+    config_setint("cursor_shape", (VteTerminalCursorShape)status);
     
     for (i=0; i<g_list_length (tw->terms); i++) {
         tt = g_list_nth_data (tw->terms, i);
-        vte_terminal_set_cursor_shape (VTE_TERMINAL(tt->vte_term), cursor_shape);
+        vte_terminal_set_cursor_shape (VTE_TERMINAL(tt->vte_term), (VteTerminalCursorShape)status);
     }
 }
 
@@ -2119,7 +2110,7 @@ static void set_wizard_state_from_config () {
 
     CHECK_BUTTON ("check_terminal_bell", "bell");
     CHECK_BUTTON ("check_cursor_blinks", "blinks");
-    COMBO_BOX ("vte_cursor_type", "cursor_type");
+    COMBO_BOX ("vte_cursor_shape", "cursor_shape");
 
     CHECK_BUTTON ("check_enable_antialiasing", "antialias");
     CHECK_BUTTON ("check_allow_bold_text", "bold");
@@ -2266,7 +2257,7 @@ static void connect_wizard_signals ()
 
     CONNECT_SIGNAL ("check_terminal_bell","toggled",check_terminal_bell_toggled_cb);
     CONNECT_SIGNAL ("check_cursor_blinks","toggled",check_cursor_blinks_toggled_cb);
-    CONNECT_SIGNAL ("vte_cursor_type","changed", vte_cursor_type_cb);
+    CONNECT_SIGNAL ("vte_cursor_shape","changed", vte_cursor_shape_cb);
  
     CONNECT_SIGNAL ("check_start_fullscreen", "toggled", check_start_fullscreen_cb);
 

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -897,6 +897,34 @@ static void check_allow_bold_text_toggled_cb (GtkWidget *w)
     }
 }
 
+static void vte_cursor_type_cb (GtkWidget *w)
+{
+    VteTerminalCursorShape cursor_shape;
+    gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
+
+    switch (status) {
+        case 1:
+            cursor_shape = VTE_CURSOR_SHAPE_IBEAM;
+            break;
+        case 2:
+            cursor_shape = VTE_CURSOR_SHAPE_UNDERLINE;
+            break;
+        default: 
+            cursor_shape = VTE_CURSOR_SHAPE_BLOCK;
+            status=0;
+            break;
+    }
+    
+    gint i;
+    tilda_term *tt;
+    config_setint("cursor_type", status);
+    
+    for (i=0; i<g_list_length (tw->terms); i++) {
+        tt = g_list_nth_data (tw->terms, i);
+        vte_terminal_set_cursor_shape (VTE_TERMINAL(tt->vte_term), cursor_shape);
+    }
+}
+
 static void combo_non_focus_pull_up_behaviour_cb (GtkWidget *w)
 {
     const gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
@@ -1552,6 +1580,30 @@ static void combo_colorschemes_changed_cb (GtkWidget *w)
         }
     }
 }
+static void colorbutton_cursor_color_set_cb (GtkWidget *w)
+{
+    const GtkWidget *combo_colorschemes =
+        GTK_WIDGET (gtk_builder_get_object (xml, "combo_colorschemes"));
+
+    gint i;
+    tilda_term *tt;
+    GdkRGBA gdk_cursor_color;
+    
+    /* The user just changed colors manually, so set the scheme to "Custom" */
+    gtk_combo_box_set_active (GTK_COMBO_BOX(combo_colorschemes), 0);
+    config_setint ("scheme", 0);
+    
+    /* Now get the color that was set, save it, then set it */
+    gtk_color_chooser_get_rgba (GTK_COLOR_CHOOSER(w), &gdk_cursor_color);
+    config_setint ("cursor_red", GUINT16_FROM_FLOAT(gdk_cursor_color.red));
+    config_setint ("cursor_green", GUINT16_FROM_FLOAT(gdk_cursor_color.green));
+    config_setint ("cursor_blue", GUINT16_FROM_FLOAT(gdk_cursor_color.blue));
+    
+    for (i=0; i<g_list_length (tw->terms); i++) {
+        tt = g_list_nth_data (tw->terms, i);
+        vte_terminal_set_color_cursor_rgba (VTE_TERMINAL(tt->vte_term), &gdk_cursor_color);
+    }
+}
 
 static void colorbutton_text_color_set_cb (GtkWidget *w)
 {
@@ -2053,7 +2105,7 @@ static void initialize_geometry_spinners() {
 /* Read all state from the config system, and put it into
  * its visual representation in the wizard. */
 static void set_wizard_state_from_config () {
-    GdkRGBA text_color, back_color;
+    GdkRGBA text_color, back_color, cursor_color;
     gint i;
 
     /* General Tab */
@@ -2067,6 +2119,7 @@ static void set_wizard_state_from_config () {
 
     CHECK_BUTTON ("check_terminal_bell", "bell");
     CHECK_BUTTON ("check_cursor_blinks", "blinks");
+    COMBO_BOX ("vte_cursor_type", "cursor_type");
 
     CHECK_BUTTON ("check_enable_antialiasing", "antialias");
     CHECK_BUTTON ("check_allow_bold_text", "bold");
@@ -2137,6 +2190,11 @@ static void set_wizard_state_from_config () {
     back_color.blue =  GUINT16_TO_FLOAT(config_getint ("back_blue"));
     back_color.alpha = 1.0;
     COLOR_CHOOSER ("colorbutton_back", &back_color);
+    cursor_color.red = GUINT16_TO_FLOAT(config_getint ("cursor_red"));
+    cursor_color.green = GUINT16_TO_FLOAT(config_getint ("cursor_green"));
+    cursor_color.blue = GUINT16_TO_FLOAT(config_getint ("cursor_blue"));
+    cursor_color.alpha = 1.0;
+    COLOR_CHOOSER ("colorbutton_cursor", &cursor_color);
 
     COMBO_BOX ("combo_palette_scheme", "palette_scheme");
 
@@ -2208,7 +2266,8 @@ static void connect_wizard_signals ()
 
     CONNECT_SIGNAL ("check_terminal_bell","toggled",check_terminal_bell_toggled_cb);
     CONNECT_SIGNAL ("check_cursor_blinks","toggled",check_cursor_blinks_toggled_cb);
-
+    CONNECT_SIGNAL ("vte_cursor_type","changed", vte_cursor_type_cb);
+ 
     CONNECT_SIGNAL ("check_start_fullscreen", "toggled", check_start_fullscreen_cb);
 
     CONNECT_SIGNAL ("check_enable_antialiasing","toggled",check_enable_antialiasing_toggled_cb);
@@ -2261,6 +2320,7 @@ static void connect_wizard_signals ()
     CONNECT_SIGNAL ("combo_colorschemes","changed",combo_colorschemes_changed_cb);
     CONNECT_SIGNAL ("colorbutton_text","color-set",colorbutton_text_color_set_cb);
     CONNECT_SIGNAL ("colorbutton_back","color-set",colorbutton_back_color_set_cb);
+    CONNECT_SIGNAL ("colorbutton_cursor","color-set",colorbutton_cursor_color_set_cb);
     CONNECT_SIGNAL ("combo_palette_scheme","changed",combo_palette_scheme_changed_cb);
     for(i = 0; i < TERMINAL_PALETTE_SIZE; i++)
     {

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -899,7 +899,7 @@ static void check_allow_bold_text_toggled_cb (GtkWidget *w)
 
 static void vte_cursor_shape_cb (GtkWidget *w)
 {
-    gint i;
+    guint i;
     tilda_term *tt;
     gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
     
@@ -1576,7 +1576,7 @@ static void colorbutton_cursor_color_set_cb (GtkWidget *w)
     const GtkWidget *combo_colorschemes =
         GTK_WIDGET (gtk_builder_get_object (xml, "combo_colorschemes"));
 
-    gint i;
+    guint i;
     tilda_term *tt;
     GdkRGBA gdk_cursor_color;
     


### PR DESCRIPTION
#133 #99
I based this on Vaygr's patch, added a drop-down toggle for cursor type, and switched from color to rgba values. Also I skipped over the anti-aliasing changes on account of https://github.com/lanoxx/tilda/issues/127. 

One thing I'm curious about are the status sanity checks: https://github.com/pik/tilda/blob/bddc5679c2bf42b17719135e474c7052f76f0ac9/src/wizard.c#L932. I added a default correction in the switch https://github.com/pik/tilda/blob/bddc5679c2bf42b17719135e474c7052f76f0ac9/src/wizard.c#L912 - but I don't really follow how can a drop-down toggle mess this up? Are those just artifacts from older code? 
