### PR TITLE
port Tilda VTE 2.90 ->2.91

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,22 @@ if test "x$enable_lto" = "xyes"; then
     LDFLAGS="$LDFLAGS $CFLAGS -fuse-linker-plugin"
 fi
 
+AC_ARG_ENABLE([vte-2.91],
+		[AS_HELP_STRING([--enable-vte-2.91],
+						[compile with libvte2.91 [default=no]])],
+		[enable_vte_291=$enableval],
+		[enable_vte_291=no])
+        
+if test "x$enable_vte_291" = "xyes"; then
+    vte_package="vte-2.91"
+    AC_DEFINE([VTE_291], [1], [VTE Version])
+else
+    vte_package="vte-2.90"
+    AC_DEFINE([VTE_290], [1], [VTE Version])
+fi
+
+AC_DEFINE_UNQUOTED([VTE_VERSION], ["$vte_package"], [The version of VTE to compile with])
+AM_CONDITIONAL([VTE_290], [test "x$enable_vte_291" = "xno"])
 
 AC_PATH_PROG(GLIB_COMPILE_RESOURCES, glib-compile-resources, no)
 if test x$GLIB_COMPILE_RESOURCES = xno; then
@@ -132,7 +148,7 @@ AM_GNU_GETTEXT([external])
 # Checks for libraries.
 PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES([GTK], [gtk+-3.0 >= 3.0.0])
-PKG_CHECK_MODULES([VTE], [vte-2.90])
+PKG_CHECK_MODULES([VTE], [$vte_package]) 
 PKG_CHECK_MODULES([LIBCONFUSE], [libconfuse])
 PKG_CHECK_MODULES([X11], [x11])
 
@@ -185,5 +201,6 @@ echo "
         compiler:                      ${CC}
         cflags:                        ${cflaglines}
         Maintainer mode:               ${USE_MAINTAINER_MODE}
+        VTE:                           ${vte_package}
         Use *_DISABLE_DEPRECATED:      ${enable_deprecation_flags}
 "

--- a/configure.ac
+++ b/configure.ac
@@ -126,7 +126,6 @@ else
     AC_DEFINE([VTE_290], [1], [VTE Version])
 fi
 
-AC_DEFINE_UNQUOTED([VTE_VERSION], ["$vte_package"], [The version of VTE to compile with])
 AM_CONDITIONAL([VTE_290], [test "x$enable_vte_291" = "xno"])
 
 AC_PATH_PROG(GLIB_COMPILE_RESOURCES, glib-compile-resources, no)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,9 +1,27 @@
 # vim: set noexpandtab ts=8 sts=8 sw=8:
 
 bin_PROGRAMS += src/tilda
+	
+# Build VTE version compatible tilda.ui
+BUILT_SOURCES = cleanui src/tilda.ui
+
+#Rebuild ui for each make run
+.PHONY: cleanui
+cleanui: 
+	rm -f src/tilda.ui
+	
+#Rule to compile tilda.ui 
+src/tilda.ui:
+if VTE_290
+	sed -r "s#<!--@VTE2.90|@VTE2.90-->##" src/tilda.ui.pre > src/tilda.ui
+else
+	cat src/tilda.ui.pre > src/tilda.ui
+endif
+
+
 
 # Rules to compile resources
-src/glade-resources.h: src/glade-resources.gresource.xml
+src/glade-resources.h: src/glade-resources.gresource.xml src/tilda.ui
 	$(GLIB_COMPILE_RESOURCES) --generate $< --target=$@ --sourcedir=$(srcdir)/src
 src/glade-resources.c: src/glade-resources.gresource.xml
 	$(GLIB_COMPILE_RESOURCES) --generate $< --target=$@ --sourcedir=$(srcdir)/src
@@ -63,4 +81,4 @@ src_tilda_LDADD = $(AM_LDADD) \
 EXTRA_DIST += src/glade-resources.gresource.xml \
 		src/tilda.ui
 
-CLEANFILES += src/glade-resources.h src/glade-resources.c
+CLEANFILES += src/glade-resources.h src/glade-resources.c src/tilda.ui

--- a/src/configsys.c
+++ b/src/configsys.c
@@ -39,7 +39,6 @@ static cfg_opt_t config_opts[] = {
 
     /* strings */
     CFG_STR("tilda_config_version", PACKAGE_VERSION, CFGF_NONE),
-    CFG_STR("image", NULL, CFGF_NONE),
     CFG_STR("command", "", CFGF_NONE),
     CFG_STR("font", "Monospace 11", CFGF_NONE),
     CFG_STR("key", NULL, CFGF_NONE),
@@ -69,7 +68,6 @@ static cfg_opt_t config_opts[] = {
     CFG_STR("background_color", "white", CFGF_NONE),
     CFG_STR("working_dir", NULL, CFGF_NONE),
     CFG_STR("web_browser", "x-www-browser", CFGF_NONE),
-    CFG_STR("word_chars", DEFAULT_WORD_CHARS, CFGF_NONE),
     CFG_STR("increase_font_size_key", "<Control>equal", CFGF_NONE),
     CFG_STR("decrease_font_size_key", "<Control>minus", CFGF_NONE),
     CFG_STR("normalize_font_size_key", "<Control>0", CFGF_NONE),
@@ -80,7 +78,6 @@ static cfg_opt_t config_opts[] = {
     CFG_INT("max_height", 150, CFGF_NONE),
     CFG_INT("min_width", 1, CFGF_NONE),
     CFG_INT("min_height", 1, CFGF_NONE),
-    CFG_INT("transparency", 0, CFGF_NONE),
     CFG_INT("x_pos", 0, CFGF_NONE),
     CFG_INT("y_pos", 0, CFGF_NONE),
     CFG_INT("tab_pos", 0, CFGF_NONE),
@@ -137,12 +134,10 @@ static cfg_opt_t config_opts[] = {
 
     /* booleans */
     CFG_BOOL("scroll_history_infinite", FALSE, CFGF_NONE),
-    CFG_BOOL("scroll_background", TRUE, CFGF_NONE),
     CFG_BOOL("scroll_on_output", FALSE, CFGF_NONE),
     CFG_BOOL("notebook_border", FALSE, CFGF_NONE),
     CFG_BOOL("antialias", TRUE, CFGF_NONE),
     CFG_BOOL("scrollbar", FALSE, CFGF_NONE),
-    CFG_BOOL("use_image", FALSE, CFGF_NONE),
     CFG_BOOL("grab_focus", TRUE, CFGF_NONE),
     CFG_BOOL("above", TRUE, CFGF_NONE),
     CFG_BOOL("notaskbar", TRUE, CFGF_NONE),
@@ -167,6 +162,16 @@ static cfg_opt_t config_opts[] = {
     CFG_BOOL("inherit_working_dir", TRUE, CFGF_NONE),
     CFG_BOOL("command_login_shell", FALSE, CFGF_NONE),
     CFG_BOOL("start_fullscreen", FALSE, CFGF_NONE),
+
+    /* Config settings for VTE-2.90 features */
+    CFG_STR("word_chars", DEFAULT_WORD_CHARS, CFGF_NONE),
+    CFG_STR("image", NULL, CFGF_NONE),
+    CFG_BOOL("scroll_background", TRUE, CFGF_NONE),
+    CFG_BOOL("use_image", FALSE, CFGF_NONE),
+    CFG_INT("transparency", 0, CFGF_NONE),
+#if VTE_VERSION_MINOR >= 9 && VTE_VERSION_MICRO >= 1  /* VTE-2.91 */
+    CFG_INT("back_alpha", 0xffff, CFGF_NONE), 
+#endif
     CFG_END()
 };
 
@@ -214,7 +219,13 @@ gint config_init (const gchar *config_file)
             return ret;
         }
 	}
-
+#ifndef VTE_290
+    /* Deprecate old config settings 
+     * This is a lame work around until we get a permenant solution to 
+     * libconfuse lacking for this functionality 
+     */
+    
+#endif
     #ifndef NO_THREADSAFE
         g_mutex_init(&mutex);
     #endif

--- a/src/tilda.c
+++ b/src/tilda.c
@@ -322,14 +322,14 @@ static gboolean parse_cli (int argc, char *argv[])
     gchar *command = config_getstr ("command");
     gchar *font = config_getstr ("font");
     gchar *working_dir = config_getstr ("working_dir");
-    
-#ifdef VTE_290    
+
+#ifdef VTE_290
     gchar *image = config_getstr ("image");
     gint transparency = config_getint ("transparency");
 #else
     gint back_alpha = config_getint ("back_alpha");
 #endif
-   
+
     gint lines = config_getint ("lines");
     gint x_pos = config_getint ("x_pos");
     gint y_pos = config_getint ("y_pos");
@@ -356,7 +356,7 @@ static gboolean parse_cli (int argc, char *argv[])
 #ifdef VTE_290
         { "image",              'B', 0, G_OPTION_ARG_STRING,    &image,             N_("Set Background Image"), NULL },
         { "transparency",       't', 0, G_OPTION_ARG_INT,       &transparency,      N_("Opaqueness: 0-100%"), NULL },
-#else 
+#else
         { "background-alpha",       't', 0, G_OPTION_ARG_INT,       &back_alpha,      N_("Opaqueness: 0-100%"), NULL },
 #endif
         { "config",             'C', 0, G_OPTION_ARG_NONE,      &show_config,       N_("Show Configuration Wizard"), NULL },
@@ -451,7 +451,7 @@ static gboolean parse_cli (int argc, char *argv[])
         config_setbool ("enable_transparency", transparency);
         config_setint ("transparency", transparency);
     }
-#else 
+#else
     if (back_alpha != config_getint ("back_alpha"))
     {
         config_setbool ("enable_transparency", ~back_alpha & 0xffff);
@@ -634,7 +634,10 @@ int main (int argc, char *argv[])
     DEBUG_FUNCTION ("main");
 
     tilda_window tw;
+    /* NULL set the tw pointers so we can get a clean exit on initialization failure */
+    memset(&tw, 0, sizeof(tilda_window));
 
+    fprintf(stderr, "VTE_VERSION %i.%i.%i\n", VTE_MAJOR_VERSION, VTE_MINOR_VERSION, VTE_MICRO_VERSION);
     struct sigaction sa;
     struct lock_info lock;
     gboolean need_wizard = FALSE;
@@ -744,6 +747,7 @@ int main (int argc, char *argv[])
     gboolean success = tilda_window_init (config_file, lock.instance, &tw);
 
     if(!success) {
+        fprintf(stderr, "tilda.c: initialization failed\n");
         goto initialization_failed;
     }
 
@@ -808,7 +812,6 @@ initialization_failed:
     close(lock.file_descriptor);
     g_free (lock_file);
     g_free (config_file);
-
     return 0;
 }
 

--- a/src/tilda.h
+++ b/src/tilda.h
@@ -44,3 +44,13 @@ struct lock_info
 G_END_DECLS
 
 #endif
+
+/* Future compatibility with VTE-2.90 */
+#ifndef VTE_290 
+#define vte_terminal_set_colors_rgba vte_terminal_set_colors
+#define vte_terminal_set_color_background_rgba vte_terminal_set_color_background
+#define vte_terminal_set_color_foreground_rgba vte_terminal_set_color_foreground
+#define vte_terminal_set_color_cursor_rgba vte_terminal_set_color_cursor
+#define VteTerminalCursorShape VteCursorShape
+#endif
+

--- a/src/tilda.ui.pre
+++ b/src/tilda.ui.pre
@@ -1062,7 +1062,8 @@
                 <property name="row_spacing">4</property>
                 <property name="column_homogeneous">True</property>
                 <child>
-                  <object class="GtkFrame" id="frame_word_chars">
+                <!--@VTE_WORD_CHARS
+                <object class="GtkFrame" id="frame_word_chars">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
@@ -1134,6 +1135,7 @@
                     <property name="height">1</property>
                   </packing>
                 </child>
+                @VTE_WORD_CHARS--> 
                 <child>
                   <object class="GtkFrame" id="frame_url">
                     <property name="visible">True</property>
@@ -2073,6 +2075,7 @@
                                 <property name="height">1</property>
                               </packing>
                             </child>
+                            <!--@VTE2.90
                             <child>
                               <object class="GtkFileChooserButton" id="button_background_image">
                                 <property name="visible">True</property>
@@ -2101,6 +2104,7 @@
                                 <property name="height">1</property>
                               </packing>
                             </child>
+                            @VTE2.90-->
                             <child>
                               <object class="GtkCheckButton" id="check_animated_pulldown">
                                 <property name="label" translatable="yes">Animated Pulldown</property>
@@ -2852,6 +2856,7 @@
                             <property name="height">1</property>
                           </packing>
                         </child>
+                        <!--@VTE2.90
                         <child>
                           <object class="GtkCheckButton" id="check_scroll_background">
                             <property name="label" translatable="yes">Scroll Background</property>
@@ -2868,6 +2873,7 @@
                             <property name="height">1</property>
                           </packing>
                         </child>
+                        @VTE2.90-->
                         <child>
                           <object class="GtkGrid" id="grid5">
                             <property name="visible">True</property>

--- a/src/tilda.ui.pre
+++ b/src/tilda.ui.pre
@@ -1061,9 +1061,9 @@
                 <property name="margin_bottom">4</property>
                 <property name="row_spacing">4</property>
                 <property name="column_homogeneous">True</property>
+                <!--@VTE2.90
                 <child>
-                <!--@VTE_WORD_CHARS
-                <object class="GtkFrame" id="frame_word_chars">
+                    <object class="GtkFrame" id="frame_word_chars">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
@@ -1135,7 +1135,7 @@
                     <property name="height">1</property>
                   </packing>
                 </child>
-                @VTE_WORD_CHARS--> 
+                @VTE2.90--> 
                 <child>
                   <object class="GtkFrame" id="frame_url">
                     <property name="visible">True</property>

--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -40,7 +40,6 @@ static gint start_shell (struct tilda_term_ *tt, gboolean ignore_custom_command,
 static gint tilda_term_config_defaults (tilda_term *tt);
 static void child_exited_cb (GtkWidget *widget, gpointer data);
 static void window_title_changed_cb (GtkWidget *widget, gpointer data);
-static void status_line_changed_cb (GtkWidget *widget, gpointer data);
 static int button_press_cb (GtkWidget *widget, GdkEventButton *event, gpointer data);
 static gboolean key_press_cb (GtkWidget *widget, GdkEvent  *event, tilda_term *terminal);
 static void iconify_window_cb (GtkWidget *widget, gpointer data);
@@ -51,6 +50,9 @@ static void maximize_window_cb (GtkWidget *widget, gpointer data);
 static void restore_window_cb (GtkWidget *widget, gpointer data);
 static void refresh_window_cb (GtkWidget *widget, gpointer data);
 static void move_window_cb (GtkWidget *widget, guint x, guint y, gpointer data);
+#ifdef VTE_290
+static void status_line_changed_cb (GtkWidget *widget, gpointer data);
+#endif
 
 gint tilda_term_free (struct tilda_term_ *term)
 {
@@ -141,8 +143,10 @@ struct tilda_term_ *tilda_term_init (struct tilda_window_ *tw)
                       G_CALLBACK(window_title_changed_cb), term);
     g_signal_connect (G_OBJECT(term->vte_term), "eof",
                       G_CALLBACK(child_exited_cb), term);
+#ifdef VTE_290
     g_signal_connect (G_OBJECT(term->vte_term), "status-line-changed",
                       G_CALLBACK(status_line_changed_cb), term);
+#endif
     g_signal_connect (G_OBJECT(term->vte_term), "button-press-event",
                       G_CALLBACK(button_press_cb), term);
     g_signal_connect (G_OBJECT(term->vte_term), "key-press-event",
@@ -257,6 +261,7 @@ static void window_title_changed_cb (GtkWidget *widget, gpointer data)
     g_free (title);
 }
 
+#ifdef VTE_290
 static void status_line_changed_cb (GtkWidget *widget, G_GNUC_UNUSED gpointer data)
 {
     DEBUG_FUNCTION ("status_line_changed_cb");
@@ -264,6 +269,7 @@ static void status_line_changed_cb (GtkWidget *widget, G_GNUC_UNUSED gpointer da
 
     g_print ("Status = `%s'.\n", vte_terminal_get_status_line (VTE_TERMINAL(widget)));
 }
+#endif
 
 static void iconify_window_cb (G_GNUC_UNUSED GtkWidget *widget, gpointer data)
 {
@@ -441,7 +447,7 @@ static gint start_shell (struct tilda_term_ *tt, gboolean ignore_custom_command,
         char **envv = malloc(2*sizeof(void *));
         envv[0] = getenv("PATH");
         envv[1] = NULL;
-
+#ifdef VTE_290
         ret = vte_terminal_fork_command_full (VTE_TERMINAL (tt->vte_term),
             VTE_PTY_DEFAULT, /* VtePtyFlags pty_flags */
             working_dir, /* const char *working_directory */
@@ -453,7 +459,20 @@ static gint start_shell (struct tilda_term_ *tt, gboolean ignore_custom_command,
             &tt->pid, /* GPid *child_pid */
             NULL  /* GError **error */
             );
-
+#else
+        ret = vte_terminal_spawn_sync (VTE_TERMINAL (tt->vte_term),
+            VTE_PTY_DEFAULT, /* VtePtyFlags pty_flags */
+            working_dir, /* const char *working_directory */
+            argv, /* char **argv */
+            envv, /* char **envv */
+            G_SPAWN_SEARCH_PATH,    /* GSpawnFlags spawn_flags */
+            NULL, /* GSpawnChildSetupFunc child_setup */
+            NULL, /* gpointer child_setup_data */
+            &tt->pid, /* GPid *child_pid */
+            NULL, /* GCancellable * cancellable, */
+            NULL  /* GError **error */
+            );
+#endif
         g_strfreev (argv);
         g_free (envv);
 
@@ -513,7 +532,7 @@ launch_default_shell:
         argv[0] = default_command;
         argv[1] = NULL;
     }
-
+#ifdef VTE_290
     ret = vte_terminal_fork_command_full (VTE_TERMINAL (tt->vte_term),
         VTE_PTY_DEFAULT, /* VtePtyFlags pty_flags */
         working_dir, /* const char *working_directory */
@@ -525,6 +544,20 @@ launch_default_shell:
         &tt->pid, /* GPid *child_pid */
         NULL  /* GError **error */
         );
+#else
+    ret = vte_terminal_spawn_sync (VTE_TERMINAL (tt->vte_term),
+        VTE_PTY_DEFAULT, /* VtePtyFlags pty_flags */
+        working_dir, /* const char *working_directory */
+        argv, /* char **argv */
+        NULL, /* char **envv */
+        flags,    /* GSpawnFlags spawn_flags */
+        NULL, /* GSpawnChildSetupFunc child_setup */
+        NULL, /* gpointer child_setup_data */
+        &tt->pid, /* GPid *child_pid */
+        NULL, /* GCancellable *cancellable */
+        NULL  /* GError **error */
+        );
+#endif
     g_free(argv1);
     g_free (argv);
 
@@ -588,8 +621,6 @@ static gint tilda_term_config_defaults (tilda_term *tt)
 {
     DEBUG_FUNCTION ("tilda_term_config_defaults");
     DEBUG_ASSERT (tt != NULL);
-
-    gdouble transparency_level = 0.0;
     GdkRGBA fg, bg, cc;
     gchar* word_chars;
     gint i;
@@ -599,7 +630,12 @@ static gint tilda_term_config_defaults (tilda_term *tt)
     bg.red   =    GUINT16_TO_FLOAT(config_getint ("back_red"));
     bg.green =    GUINT16_TO_FLOAT(config_getint ("back_green"));
     bg.blue  =    GUINT16_TO_FLOAT(config_getint ("back_blue"));
+#ifdef VTE_290 
     bg.alpha =    1.0;
+    gdouble transparency_level = 0.0;
+#else
+    bg.alpha =    (config_getbool("enable_transparency") ? GUINT16_TO_FLOAT(config_getint ("back_alpha")) : 1.0);
+#endif 
 
     fg.red   =    GUINT16_TO_FLOAT(config_getint ("text_red"));
     fg.green =    GUINT16_TO_FLOAT(config_getint ("text_green"));
@@ -622,8 +658,9 @@ static gint tilda_term_config_defaults (tilda_term *tt)
 
     /** Bells **/
     vte_terminal_set_audible_bell (VTE_TERMINAL(tt->vte_term), config_getbool ("bell"));
+#ifdef VTE_290
     vte_terminal_set_visible_bell (VTE_TERMINAL(tt->vte_term), config_getbool ("bell"));
-
+#endif
     /** Cursor **/
     vte_terminal_set_cursor_blink_mode (VTE_TERMINAL(tt->vte_term),
             (config_getbool ("blinks"))?VTE_CURSOR_BLINK_ON:VTE_CURSOR_BLINK_OFF);
@@ -637,7 +674,9 @@ static gint tilda_term_config_defaults (tilda_term *tt)
     vte_terminal_set_cursor_shape(VTE_TERMINAL(tt->vte_term), (VteTerminalCursorShape)cursor_shape);
 
     /** Scrolling **/
+#ifdef VTE_290
     vte_terminal_set_scroll_background (VTE_TERMINAL(tt->vte_term), config_getbool ("scroll_background"));
+#endif
     vte_terminal_set_scroll_on_output (VTE_TERMINAL(tt->vte_term), config_getbool ("scroll_on_output"));
     vte_terminal_set_scroll_on_keystroke (VTE_TERMINAL(tt->vte_term), config_getbool ("scroll_on_key"));
 
@@ -688,7 +727,7 @@ static gint tilda_term_config_defaults (tilda_term *tt)
             vte_terminal_set_delete_binding (VTE_TERMINAL(tt->vte_term), VTE_ERASE_AUTO);
             break;
     }
-
+#ifdef VTE_290 /* VTE 2.90 only */
     /** Word chars **/
     word_chars =  config_getstr ("word_chars");
     if (NULL == word_chars || '\0' == *word_chars) {
@@ -701,7 +740,6 @@ static gint tilda_term_config_defaults (tilda_term *tt)
         vte_terminal_set_background_image_file (VTE_TERMINAL(tt->vte_term), config_getstr ("image"));
     else
         vte_terminal_set_background_image_file (VTE_TERMINAL(tt->vte_term), NULL);
-
     transparency_level = ((gdouble) config_getint ("transparency"))/100;
 
     if (config_getbool ("enable_transparency") && transparency_level > 0)
@@ -710,7 +748,7 @@ static gint tilda_term_config_defaults (tilda_term *tt)
         vte_terminal_set_opacity (VTE_TERMINAL (tt->vte_term), (1.0 - transparency_level) * 0xffff);
         vte_terminal_set_background_transparent (VTE_TERMINAL(tt->vte_term), !tt->tw->have_argb_visual);
     }
-
+#endif
     return 0;
 }
 

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -163,8 +163,10 @@ void tilda_window_toggle_transparency (tilda_window *tw)
     guint i;
     gboolean status = !config_getbool ("enable_transparency");
     config_setbool ("enable_transparency", status); 
+#ifdef VTE_290
     gdouble transparency_level = 0.0;
     transparency_level = ((gdouble) config_getint ("transparency"))/100;
+
     if (status)
     {
         for (i=0; i<g_list_length (tw->terms); i++) {
@@ -183,6 +185,18 @@ void tilda_window_toggle_transparency (tilda_window *tw)
             vte_terminal_set_opacity (VTE_TERMINAL(tt->vte_term), 0xffff);
         }
     } 
+#else
+    GdkRGBA bg;
+    bg.red   =    GUINT16_TO_FLOAT(config_getint ("back_red"));
+    bg.green =    GUINT16_TO_FLOAT(config_getint ("back_green"));
+    bg.blue  =    GUINT16_TO_FLOAT(config_getint ("back_blue"));
+    bg.alpha =    (status ? GUINT16_TO_FLOAT(config_getint ("back_alpha")) : 1.0);
+    
+    for (i=0; i<g_list_length (tw->terms); i++) {
+            tt = g_list_nth_data (tw->terms, i);
+            vte_terminal_set_color_background(VTE_TERMINAL(tt->vte_term), &bg);
+        }    
+#endif
 }
 
 gint toggle_searchbar_cb (tilda_window *tw)

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -147,22 +147,22 @@ gint toggle_fullscreen_cb (tilda_window *tw)
     // It worked. Having this return GDK_EVENT_STOP makes the callback not carry the
     // keystroke into the vte terminal widget.
     return GDK_EVENT_STOP;
-} 
+}
 
 gint toggle_transparency_cb (tilda_window *tw)
 {
-    DEBUG_FUNCTION ("toggle_transparency"); 
+    DEBUG_FUNCTION ("toggle_transparency");
     DEBUG_ASSERT (tw != NULL);
     tilda_window_toggle_transparency(tw);
     return GDK_EVENT_STOP;
 }
 
-void tilda_window_toggle_transparency (tilda_window *tw) 
+void tilda_window_toggle_transparency (tilda_window *tw)
 {
     tilda_term *tt;
     guint i;
     gboolean status = !config_getbool ("enable_transparency");
-    config_setbool ("enable_transparency", status); 
+    config_setbool ("enable_transparency", status);
 #ifdef VTE_290
     gdouble transparency_level = 0.0;
     transparency_level = ((gdouble) config_getint ("transparency"))/100;
@@ -184,24 +184,24 @@ void tilda_window_toggle_transparency (tilda_window *tw)
             vte_terminal_set_background_transparent(VTE_TERMINAL(tt->vte_term), FALSE);
             vte_terminal_set_opacity (VTE_TERMINAL(tt->vte_term), 0xffff);
         }
-    } 
+    }
 #else
     GdkRGBA bg;
     bg.red   =    GUINT16_TO_FLOAT(config_getint ("back_red"));
     bg.green =    GUINT16_TO_FLOAT(config_getint ("back_green"));
     bg.blue  =    GUINT16_TO_FLOAT(config_getint ("back_blue"));
     bg.alpha =    (status ? GUINT16_TO_FLOAT(config_getint ("back_alpha")) : 1.0);
-    
+
     for (i=0; i<g_list_length (tw->terms); i++) {
             tt = g_list_nth_data (tw->terms, i);
             vte_terminal_set_color_background(VTE_TERMINAL(tt->vte_term), &bg);
-        }    
+        }
 #endif
 }
 
 gint toggle_searchbar_cb (tilda_window *tw)
 {
-    DEBUG_FUNCTION ("toggle_searbar"); 
+    DEBUG_FUNCTION ("toggle_searbar");
     DEBUG_ASSERT (tw != NULL);
     DEBUG_ASSERT (tw->search != NULL);
     gboolean visible = !gtk_widget_get_visible(tw->search->search_box);
@@ -664,8 +664,8 @@ static gint tilda_window_setup_keyboard_accelerators (tilda_window *tw)
     tilda_add_config_accelerator_by_path("paste_key",      "<tilda>/context/Paste",             G_CALLBACK(cpaste),                         tw);
     tilda_add_config_accelerator_by_path("fullscreen_key", "<tilda>/context/Toggle Fullscreen", G_CALLBACK(toggle_fullscreen_cb),           tw);
     tilda_add_config_accelerator_by_path("quit_key",       "<tilda>/context/Quit",              G_CALLBACK(gtk_main_quit),                  tw);
-    tilda_add_config_accelerator_by_path("toggle_transparency_key", "<tilda>/context/Toggle Transparency", G_CALLBACK(toggle_transparency_cb),      tw); 
-    tilda_add_config_accelerator_by_path("toggle_searchbar_key", "<tilda>/context/Toggle Searchbar", G_CALLBACK(toggle_searchbar_cb),      tw); 
+    tilda_add_config_accelerator_by_path("toggle_transparency_key", "<tilda>/context/Toggle Transparency", G_CALLBACK(toggle_transparency_cb),      tw);
+    tilda_add_config_accelerator_by_path("toggle_searchbar_key", "<tilda>/context/Toggle Searchbar", G_CALLBACK(toggle_searchbar_cb),      tw);
 
     tilda_add_config_accelerator_by_path("nexttab_key",      "<tilda>/context/Next Tab",        G_CALLBACK(tilda_window_next_tab),          tw);
     tilda_add_config_accelerator_by_path("prevtab_key",      "<tilda>/context/Previous Tab",    G_CALLBACK(tilda_window_prev_tab),          tw);
@@ -731,7 +731,11 @@ static void tilda_window_search (G_GNUC_UNUSED GtkButton *button, tilda_window *
 
     GError *error = NULL;
     GRegex *regex = g_regex_new (pattern, compile_flags, G_REGEX_MATCH_NEWLINE_ANY, &error);
+#ifdef VTE_290
     vte_terminal_search_set_gregex (VTE_TERMINAL (vteTerminal), regex);
+#else
+    vte_terminal_search_set_gregex (VTE_TERMINAL (vteTerminal), regex, 0);
+#endif
     vte_terminal_search_set_wrap_around (VTE_TERMINAL (vteTerminal), wrap_on_search);
 
     gboolean search_result;
@@ -886,10 +890,10 @@ gboolean tilda_window_init (const gchar *config_file, const gint instance, tilda
 #endif
 
     if(!gtk_builder_add_from_resource (gtk_builder, "/org/tilda/tilda.ui", &error)) {
-        g_prefix_error(&error, "Error:");
+        fprintf (stderr, "Error: %s\n", error->message);
+        g_error_free(error);
         return FALSE;
     }
-
     tw->gtk_builder = gtk_builder;
 
     /* The gdk_x11_get_server_time call will hang if GDK_PROPERTY_CHANGE_MASK is not set */
@@ -1011,7 +1015,7 @@ gboolean tilda_window_init (const gchar *config_file, const gint instance, tilda
      */
     GtkWidget *main_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
     tw->search = tilda_search_box_init(tw);
-    
+
     gtk_container_add (GTK_CONTAINER(tw->window), main_box);
     gtk_box_pack_start (GTK_BOX (main_box), tw->notebook, TRUE, TRUE, 0);
     gtk_box_pack_start (GTK_BOX (main_box), tw->search->search_box, FALSE, TRUE, 0);
@@ -1039,22 +1043,26 @@ gboolean tilda_window_init (const gchar *config_file, const gint instance, tilda
 
 gint tilda_window_free (tilda_window *tw)
 {
-    gint num_pages = gtk_notebook_get_n_pages (GTK_NOTEBOOK(tw->notebook));
 
     /* Close each tab which still exists.
      * This will free their data structures automatically. */
-    while (num_pages > 0)
-    {
-        /* Close the 0th tab, which should always exist while we have
-         * some pages left in the notebook. */
-        tilda_window_close_tab (tw, 0, TRUE);
+    if (tw->notebook != NULL) {
+        gint num_pages = gtk_notebook_get_n_pages (GTK_NOTEBOOK(tw->notebook));
+        while (num_pages > 0)
+        {
+            /* Close the 0th tab, which should always exist while we have
+             * some pages left in the notebook. */
+            tilda_window_close_tab (tw, 0, TRUE);
 
-        num_pages = gtk_notebook_get_n_pages (GTK_NOTEBOOK(tw->notebook));
+            num_pages = gtk_notebook_get_n_pages (GTK_NOTEBOOK(tw->notebook));
+        }
     }
 
     g_free (tw->config_file);
     g_free (tw->search);
-    g_object_unref (G_OBJECT(tw->gtk_builder));
+    if (tw->gtk_builder != NULL) {
+        g_object_unref (G_OBJECT(tw->gtk_builder));
+    }
 
     return 0;
 }


### PR DESCRIPTION
Fixed Port (I hope) for Tilda to function correctly with VTE2.91 (based on @x2b's patch).  #94 

The following are gone from VTE and have been removed from Tilda accordingly: 
* word chars
* support for a terminal background image
* terminal visible bell 
* status line support

The following have changed with VTE2.91: 

* vte uses rgba (FLOAT) values for colors, function names changed. 
* transparency support removed in vte - replaced in tilda with background_alpha, user-experience should remain unchanged. 

The following have also been updated:

* multi-monitor selection is now by name
* hanging bug with gdk_x11_get_server_time fixed. 

@lanoxx 
This probably would have been better for history if I had committed each notable change separately - sorry about that. Not sure if now it's better to rebase into one commit, or to go back and split the first commit into at least two or three. 