### PR TITLE
fix limit_scrollback name and add check on startup

### DIFF
--- a/src/configsys.c
+++ b/src/configsys.c
@@ -135,7 +135,7 @@ static cfg_opt_t config_opts[] = {
     CFG_INT("cursor_blue", 0xffff, CFGF_NONE),
 
     /* booleans */
-    CFG_BOOL("scroll_history_infinite", FALSE, CFGF_NONE),
+    CFG_BOOL("limit_scrollback", FALSE, CFGF_NONE),
     CFG_BOOL("scroll_background", TRUE, CFGF_NONE),
     CFG_BOOL("scroll_on_output", FALSE, CFGF_NONE),
     CFG_BOOL("notebook_border", FALSE, CFGF_NONE),

--- a/src/tilda.ui
+++ b/src/tilda.ui
@@ -2759,7 +2759,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkCheckButton" id="check_infinite_scrollback">
+                          <object class="GtkCheckButton" id="check_limit_scrollback">
                             <property name="label" translatable="yes">Limit scrollback to:</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>

--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -616,7 +616,7 @@ static gint tilda_term_config_defaults (tilda_term *tt)
     vte_terminal_set_font (VTE_TERMINAL (tt->vte_term), description);
 
     /** Scrollback **/
-    vte_terminal_set_scrollback_lines (VTE_TERMINAL(tt->vte_term), config_getint ("lines"));
+    vte_terminal_set_scrollback_lines (VTE_TERMINAL(tt->vte_term), config_getbool("limit_scrollback") ? config_getint ("lines") : -1);
 
     /** Keys **/
     switch (config_getint ("backspace_key"))

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -1786,12 +1786,12 @@ static void spin_scrollback_amount_value_changed_cb (GtkWidget *w)
     }
 }
 
-static void check_infinite_scrollback_toggled_cb(GtkWidget *w)
+static void check_limit_scrollback_toggled_cb(GtkWidget *w)
 {
     // if status is false then scrollback is infinite, otherwise the spinner is active
     const gboolean hasScrollbackLimit = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(w));
 
-    config_setbool ("scroll_history_infinite", hasScrollbackLimit);
+    config_setbool ("limit_scrollback", hasScrollbackLimit);
 
     GtkWidget *spinner = (GtkWidget *) gtk_builder_get_object(xml, "spin_scrollback_amount");
     gint scrollback_lines = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON(spinner));
@@ -2201,9 +2201,10 @@ static void set_wizard_state_from_config () {
     /* Scrolling Tab */
     COMBO_BOX ("combo_scrollbar_position", "scrollbar_pos");
     SPIN_BUTTON ("spin_scrollback_amount", "lines");
-    CHECK_BUTTON ("check_infinite_scrollback", "scroll_history_infinite");
-    SET_SENSITIVE_BY_CONFIG_BOOL ("spin_scrollback_amount", "scroll_history_infinite");
-    SET_SENSITIVE_BY_CONFIG_BOOL ("label_scrollback_lines", "scroll_history_infinite");
+    CHECK_BUTTON ("check_limit_scrollback", "limit_scrollback");
+    
+    SET_SENSITIVE_BY_CONFIG_BOOL ("spin_scrollback_amount", "limit_scrollback");
+    SET_SENSITIVE_BY_CONFIG_BOOL ("label_scrollback_lines", "limit_scrollback");
     CHECK_BUTTON ("check_scroll_on_output", "scroll_on_output");
     CHECK_BUTTON ("check_scroll_on_keystroke", "scroll_on_key");
     CHECK_BUTTON ("check_scroll_background", "scroll_background");
@@ -2323,7 +2324,7 @@ static void connect_wizard_signals ()
     /* Scrolling Tab */
     CONNECT_SIGNAL ("combo_scrollbar_position","changed",combo_scrollbar_position_changed_cb);
     CONNECT_SIGNAL ("spin_scrollback_amount","value-changed",spin_scrollback_amount_value_changed_cb);
-    CONNECT_SIGNAL ("check_infinite_scrollback", "toggled", check_infinite_scrollback_toggled_cb);
+    CONNECT_SIGNAL ("check_limit_scrollback", "toggled", check_limit_scrollback_toggled_cb);
     CONNECT_SIGNAL ("check_scroll_on_output","toggled",check_scroll_on_output_toggled_cb);
     CONNECT_SIGNAL ("check_scroll_on_keystroke","toggled",check_scroll_on_keystroke_toggled_cb);
     CONNECT_SIGNAL ("check_scroll_background","toggled",check_scroll_background_toggled_cb);


### PR DESCRIPTION
limit_scrollback was incorrectly named infinite_scrollback - also tilda_terminal was not checking whether limit_scrollback was enabled or not when calling vte_terminal_set_scrollback_lines on startup. 