### PR TITLE
Fix for segfault on opening wizard

### DIFF
--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -825,6 +825,9 @@ gboolean tilda_window_init (const gchar *config_file, const gint instance, tilda
     gtk_widget_realize (tw->window);
     generate_animation_positions (tw);
 
+    /* Initialize wizard window reference to NULL */
+    tw->wizard_window = NULL;
+
     return TRUE;
 }
 

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -237,10 +237,6 @@ gint wizard (tilda_window *ltw)
 
     gchar *window_title;
 
-    if (tw->wizard_window == 0xFFFFFFFF) {
-        tw->wizard_window = NULL;
-    }
-
     /* Make sure that there isn't already a wizard showing */
     if (tw->wizard_window) {
         gtk_window_present (GTK_WINDOW (tw->wizard_window));

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -237,6 +237,10 @@ gint wizard (tilda_window *ltw)
 
     gchar *window_title;
 
+    if (tw->wizard_window == 0xFFFFFFFF) {
+        tw->wizard_window = NULL;
+    }
+
     /* Make sure that there isn't already a wizard showing */
     if (tw->wizard_window) {
         gtk_window_present (GTK_WINDOW (tw->wizard_window));


### PR DESCRIPTION
When the wizard is opened via Right click > Preference, it causes a segfault due
to `wizard()` function receives a window object (`tw`) with `tw->wizard_window`
having 0xFFFFFFFF in it. Obviously this is not a valid reference to an existing
wizard window (there were none), but this value causes the code to assume there
is already a wizard window and trying to show it.

Fixed it by simply checking if the passed in `tw->wizard_window` is 0xFFFFFFFF
and setting it to NULL.