### PR TITLE
fix copy/paste hotkeys not working after tab is relocated

### DIFF
--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -552,15 +552,17 @@ static gint ccopy (tilda_window *tw)
     DEBUG_ASSERT (tw != NULL);
     DEBUG_ASSERT (tw->notebook != NULL);
 
+    GtkWidget *current_page;
+    GList *list;
+
     gint pos = gtk_notebook_get_current_page (GTK_NOTEBOOK (tw->notebook));
-    int counter = 0;
-    for (GList *item=tw->terms; item != NULL; item=item->next) {
-        if (counter == pos) {
-            tilda_term *term = item->data;
-            vte_terminal_copy_clipboard (VTE_TERMINAL(term->vte_term));
-        }
-        counter++;
+    current_page = gtk_notebook_get_nth_page (GTK_NOTEBOOK (tw->notebook), pos);
+    list = gtk_container_get_children (GTK_CONTAINER(current_page));
+    if GTK_IS_SCROLLBAR(list->data) {
+        list = list->next;
     }
+    vte_terminal_copy_clipboard (VTE_TERMINAL(list->data));
+
     /* Stop the event's propagation */
     return TRUE;
 }
@@ -571,15 +573,16 @@ static gint cpaste (tilda_window *tw)
     DEBUG_ASSERT (tw != NULL);
     DEBUG_ASSERT (tw->notebook != NULL);
 
+    GtkWidget *current_page;
+    GList *list;
+
     gint pos = gtk_notebook_get_current_page (GTK_NOTEBOOK (tw->notebook));
-    int counter = 0;
-    for (GList *item=tw->terms; item != NULL; item=item->next) {
-        if (counter == pos) {
-            tilda_term *term = item->data;
-            vte_terminal_paste_clipboard (VTE_TERMINAL(term->vte_term));
-        }
-        counter++;
+    current_page = gtk_notebook_get_nth_page (GTK_NOTEBOOK (tw->notebook), pos);
+    list = gtk_container_get_children (GTK_CONTAINER (current_page));
+    if GTK_IS_SCROLLBAR(list->data) {
+        list = list->next;
     }
+    vte_terminal_paste_clipboard (VTE_TERMINAL(list->data));
 
     /* Stop the event's propagation */
     return TRUE;


### PR DESCRIPTION
Quick-fix for copy/paste not working when tabs are moved. #167 
 * Reverted to old lookup method 
 * Added check to make sure copy/paste still work with scrollbar on either side