### PR TITLE
temporary fix for gtk breaking fullscreen show/hide

### DIFF
--- a/src/key_grabber.c
+++ b/src/key_grabber.c
@@ -216,6 +216,10 @@ void pull (struct tilda_window_ *tw, enum pull_action action, gboolean force_hid
                                       tomboy_keybinder_get_current_event_time());
         gtk_window_move (GTK_WINDOW(tw->window), config_getint ("x_pos"), config_getint ("y_pos"));
         gtk_widget_show (GTK_WIDGET(tw->window));
+#if GTK_MINOR_VERSION >= 16
+        /* Temporary fix for GTK breaking restore on Fullscreen */
+        tilda_window_set_fullscreen(tw);
+#endif
 
         /* Nasty code to make metacity behave. Starting at metacity-2.22 they "fixed" the
          * focus stealing prevention to make the old _NET_WM_USER_TIME hack


### PR DESCRIPTION
Sorry about how late this is, it could have been done much earlier.  #151

At any rate, this is a temporary fix until we get to the new GTK version (3-17-5). I looked and the culprit code https://github.com/GNOME/gtk/blob/gtk-3-16/gtk/gtkwindow.c#L6032 appears to no longer exist in the current master of GTK. But I am running 3.17.1 on Arch and it appears to still be there (I should have reported this earlier), so it maybe sometime before everyone is running a GTK version without this bug. 



