### PR TITLE
DEBUG_FUNCTION_MESSAGE needs no-op implementation

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -77,6 +77,8 @@
 
     #define DEBUG_FUNCTION(NAME) {}
 
+    #define DEBUG_FUNCTION_MESSAGE(NAME,FORMAT,args...) {}
+
 #endif
 
 /* A macro that calls perror() with a consistent header string */


### PR DESCRIPTION
Just a quick hit... I wasn't able to build clean (i.e., without `-DDEBUG_FUNCTIONS`) because 7f7eb4e1c9314fc8222d6e5ce4524853d0cf90d3 introduces `DEBUG_FUNCTION_MESSAGE` but forgets to specify what happens for this macro when `DEBUG_FUNCTIONS` isn't defined.