### PR TITLE
Fixes #223, change minimum VTE_MINOR_VERSION to 38 instead of 40.

### DIFF
--- a/src/configsys.c
+++ b/src/configsys.c
@@ -174,7 +174,7 @@ static cfg_opt_t config_opts[] = {
     CFG_BOOL("scroll_background", FALSE, CFGF_NODEFAULT),
     CFG_BOOL("use_image", FALSE, CFGF_NODEFAULT),
     CFG_INT("transparency", 0, CFGF_NONE),
-#if VTE_MINOR_VERSION >= 40 /* VTE-2.91 */
+#if VTE_MINOR_VERSION >= 38 /* VTE-2.91 */
     CFG_INT("back_alpha", 0xffff, CFGF_NONE),
 #endif
     CFG_END()


### PR DESCRIPTION
I tested on Debian Jessie with libvte 2.91, and my build works fine.
My environment is as below. 

```bash
$ uname -a
Linux tp 3.16.0-4-amd64 #1 SMP Debian 3.16.7-ckt20-1+deb8u4 (2016-02-29) x86_64 GNU/Linux
$ dpkg -l | grep libvte
ii  libvte-2.91-0                         0.38.1-2                             amd64        Terminal emulator widget for GTK+ 3.0 - runtime files
ii  libvte-2.91-common                    0.38.1-2                             all          Terminal emulator widget for GTK+ 3.0 - common files
ii  libvte-2.91-dev                       0.38.1-2                             amd64        Terminal emulator widget for GTK+ 3.0 - development files
ii  libvte-2.91-doc                       0.38.1-2                             all          Terminal emulator widget for GTK+ 3.0 - documentation
```