### PR TITLE
Bugfix for close-tab related issues (double-close / dialog close not working)

### DIFF
--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -888,9 +888,6 @@ static void on_popup_hide (GtkWidget *widget, tilda_window *tw)
     DEBUG_ASSERT(widget != NULL);
     DEBUG_ASSERT(tw != NULL);
 
-    GAction *action = g_action_map_lookup_action (G_ACTION_MAP (tw->action_group), "close-tab");
-    g_simple_action_set_enabled (G_SIMPLE_ACTION (action), FALSE);
-
     tw->disable_auto_hide = FALSE;
 }
 

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -568,7 +568,7 @@ static gboolean goto_tab_generic (tilda_window *tw, guint tab_number)
         goto_tab (tw, tab_number - 1);
     }
 
-    return TRUE;
+    return GDK_EVENT_STOP;
 }
 
 /* These all just call the generic function since they're all basically the same
@@ -602,8 +602,7 @@ static gint ccopy (tilda_window *tw)
     }
     vte_terminal_copy_clipboard (VTE_TERMINAL(list->data));
 
-    /* Stop the event's propagation */
-    return TRUE;
+    return GDK_EVENT_STOP;
 }
 
 static gint cpaste (tilda_window *tw)
@@ -623,8 +622,7 @@ static gint cpaste (tilda_window *tw)
     }
     vte_terminal_paste_clipboard (VTE_TERMINAL(list->data));
 
-    /* Stop the event's propagation */
-    return TRUE;
+    return GDK_EVENT_STOP;
 }
 
 /* Tie a single keyboard shortcut to a callback function */
@@ -1114,7 +1112,7 @@ gint tilda_window_add_tab (tilda_window *tw)
     /* The new terminal should grab the focus automatically */
     gtk_widget_grab_focus (tt->vte_term);
 
-    return TRUE; //index;
+    return GDK_EVENT_STOP; //index;
 }
 
 gint tilda_window_close_tab (tilda_window *tw, gint tab_index, gboolean force_exit)
@@ -1193,5 +1191,5 @@ gint tilda_window_close_tab (tilda_window *tw, gint tab_index, gboolean force_ex
     /* Free the terminal, we are done with it */
     tilda_term_free (tt);
 
-    return TRUE;
+    return GDK_EVENT_STOP;
 }

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -1193,5 +1193,5 @@ gint tilda_window_close_tab (tilda_window *tw, gint tab_index, gboolean force_ex
     /* Free the terminal, we are done with it */
     tilda_term_free (tt);
 
-    return 0;
+    return TRUE;
 }


### PR DESCRIPTION
Seems like we missed a `GDK_EVENT_STOP` since these accelerators technically get added twice ? https://github.com/lanoxx/tilda/blob/master/src%2Ftilda_terminal.c#L992 

To replicate the original issue open/close the preferences dialog, then the <close-tab key-press> will close two tabs at once and the <close-tab> on the menu will no longer work. 

#218 #229 #232 
