### PR TITLE
Update URL matching regex

### DIFF
--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -32,7 +32,7 @@
 #include <vte/vte.h>
 #include <string.h>
 
-#define HTTP_REGEXP "(ftp|http)s?://[-a-zA-Z0-9.?$%&/=_~#.,:;+]*"
+#define HTTP_REGEXP "(ftp|http)s?://[\\[\\]-a-zA-Z0-9.?$%&/=_~#.,:;+]*"
 
 GdkRGBA current_palette[TERMINAL_PALETTE_SIZE];
 


### PR DESCRIPTION
I've added square brackets to `HTTP_REGEXP` so that links with literal IPv6 addresses, such as `http://[::1]:123`, can be correctly matched. 