### PR TITLE
Add command-line option to use specific config file

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,6 @@
  * Session support, so Tilda will load with the same number of tabs that it had
    upon closing.
  * Ability to rename a tab manually
- * Add -c option to specify specific configuration file for Tilda instance
 
 # Future Plans
 


### PR DESCRIPTION
This is an attempt at providing a command-line option to use a custom config file when launching Tilda.

A new option can be called, either as `-g` or as `--config-file` and followed by a path, to specify a configuration file to use for a Tilda instance. If there is no file at the specified path, the default config file for the current instance is used.

Note that the `-c` flag suggested in `TODO.md` has been discarded as it is already used for `--command`, hence `-g` is used here instead, which of course can be changed.

This is obviously still experimental.
Possible issues arise when several instances are launched using the same config file, causing keybindings to conflict between instances. A way to avoid this would be to keep track of which instance uses which config file, to make such a file unavailable for further instances. OTOH, sharing a config (or parts thereof) between instances could probably be useful in some cases.
Anyway, I thought submitting this could be a nice way to gather feedback and ideas on what kind of behaviour we would like to see here.
