### PR TITLE
Fixed tab creation, uses 'title' from configuration instead of hardcoded 'tilda'

### DIFF
--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -167,10 +167,10 @@ void tilda_window_toggle_transparency (tilda_window *tw)
 void tilda_window_refresh_transparency (tilda_window *tw)
 {
     gboolean status = config_getbool ("enable_transparency");
-    tilda_window_apply_transparency (tw, status);    
+    tilda_window_apply_transparency (tw, status);
 }
 
-void tilda_window_apply_transparency (tilda_window *tw, gboolean status) 
+void tilda_window_apply_transparency (tilda_window *tw, gboolean status)
 {
     tilda_term *tt;
     guint i;
@@ -1109,7 +1109,7 @@ gint tilda_window_add_tab (tilda_window *tw)
     }
 
     /* Create page and append to notebook */
-    label = gtk_label_new ("Tilda");
+    label = gtk_label_new (config_getstr("title"));
     /* Strangely enough, prepend puts pages on the end */
     index = gtk_notebook_append_page (GTK_NOTEBOOK(tw->notebook), tt->hbox, label);
     gtk_notebook_set_current_page (GTK_NOTEBOOK(tw->notebook), index);


### PR DESCRIPTION
When creating a new tab, Tilda was always using the title "Tilda" instead of using the one defined in the configuration file.