### PR TITLE
New tab options

### DIFF
--- a/src/configsys.c
+++ b/src/configsys.c
@@ -85,6 +85,7 @@ static cfg_opt_t config_opts[] = {
     CFG_INT("y_pos", 0, CFGF_NONE),
     CFG_INT("tab_pos", 0, CFGF_NONE),
     CFG_BOOL("expand_tabs", FALSE, CFGF_NONE),
+    CFG_BOOL("show_single_tab", FALSE, CFGF_NONE),
     CFG_INT("backspace_key", 0, CFGF_NONE),
     CFG_INT("delete_key", 1, CFGF_NONE),
     CFG_INT("d_set_title", 3, CFGF_NONE),

--- a/src/configsys.c
+++ b/src/configsys.c
@@ -84,6 +84,7 @@ static cfg_opt_t config_opts[] = {
     CFG_INT("x_pos", 0, CFGF_NONE),
     CFG_INT("y_pos", 0, CFGF_NONE),
     CFG_INT("tab_pos", 0, CFGF_NONE),
+    CFG_BOOL("expand_tabs", FALSE, CFGF_NONE),
     CFG_INT("backspace_key", 0, CFGF_NONE),
     CFG_INT("delete_key", 1, CFGF_NONE),
     CFG_INT("d_set_title", 3, CFGF_NONE),

--- a/src/tilda.ui
+++ b/src/tilda.ui
@@ -1847,6 +1847,20 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="check_expand_tabs">
+                                <property name="label" translatable="yes">Expand Tabs</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="receives_default">False</property>
+                                <property name="xalign">0</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
                               <placeholder/>
                             </child>
                           </object>

--- a/src/tilda.ui
+++ b/src/tilda.ui
@@ -1861,6 +1861,20 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="check_show_single_tab">
+                                <property name="label" translatable="yes">Show single Tab</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="receives_default">False</property>
+                                <property name="xalign">0</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
                               <placeholder/>
                             </child>
                           </object>

--- a/src/tilda.ui
+++ b/src/tilda.ui
@@ -727,35 +727,6 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkLabel" id="label_tab_pos">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Position of Tabs:</property>
-                                <property name="xalign">1</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">0</property>
-                                <property name="top_attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkComboBox" id="combo_tab_pos">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="model">model1</property>
-                                <child>
-                                  <object class="GtkCellRendererText" id="renderer1"/>
-                                  <attributes>
-                                    <attribute name="text">0</attribute>
-                                  </attributes>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
                               <object class="GtkLabel" id="label_font">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -1823,12 +1794,86 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkFrame" id="frame_extras">
+                  <object class="GtkFrame" id="frame_tabs">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label_xalign">0</property>
                     <child>
                       <object class="GtkAlignment" id="alignment9">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="left_padding">12</property>
+                        <child>
+                          <object class="GtkGrid" id="grid_tabs">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_left">4</property>
+                            <property name="margin_right">4</property>
+                            <property name="margin_top">4</property>
+                            <property name="margin_bottom">4</property>
+                            <property name="hexpand">False</property>
+                            <property name="vexpand">False</property>
+                            <property name="row_spacing">4</property>
+                            <property name="column_spacing">4</property>
+                            <property name="row_homogeneous">True</property>
+                            <property name="column_homogeneous">True</property>
+                            <child>
+                              <object class="GtkLabel" id="label_tab_pos">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Position of Tabs:</property>
+                                <property name="xalign">1</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="combo_tab_pos">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="model">model1</property>
+                                <child>
+                                  <object class="GtkCellRendererText" id="renderer1"/>
+                                  <attributes>
+                                    <attribute name="text">0</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel" id="label45">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Tabs&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkFrame" id="frame_extras">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label_xalign">0</property>
+                    <child>
+                      <object class="GtkAlignment" id="alignment10">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="left_padding">12</property>
@@ -1992,7 +2037,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">4</property>
+                    <property name="top_attach">5</property>
                   </packing>
                 </child>
               </object>

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -1123,9 +1123,11 @@ gint tilda_window_add_tab (tilda_window *tw)
             NULL);
     }
 
-    /* We should show the tabs if there are more than one tab in the notebook,
+    /* We should show the tabs if there are more than one tab in the notebook
+     * (or show single tab is set),
      * and tab position is not set to hidden */
-    if (gtk_notebook_get_n_pages (GTK_NOTEBOOK (tw->notebook)) > 1 &&
+    if ((gtk_notebook_get_n_pages (GTK_NOTEBOOK (tw->notebook)) > 1 ||
+            config_getbool("show_single_tab")) &&
             config_getint("tab_pos") != NB_HIDDEN)
         gtk_notebook_set_show_tabs (GTK_NOTEBOOK (tw->notebook), TRUE);
 

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -1115,6 +1115,14 @@ gint tilda_window_add_tab (tilda_window *tw)
     gtk_notebook_set_current_page (GTK_NOTEBOOK(tw->notebook), index);
     gtk_notebook_set_tab_reorderable (GTK_NOTEBOOK(tw->notebook), tt->hbox, TRUE);
 
+    if(config_getbool ("expand_tabs")) {
+        gtk_container_child_set (GTK_CONTAINER(tw->notebook),
+            GTK_WIDGET(tt->hbox),
+            "tab-expand", TRUE,
+            "tab-fill", TRUE,
+            NULL);
+    }
+
     /* We should show the tabs if there are more than one tab in the notebook,
      * and tab position is not set to hidden */
     if (gtk_notebook_get_n_pages (GTK_NOTEBOOK (tw->notebook)) > 1 &&

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -810,34 +810,6 @@ static void combo_non_focus_pull_up_behaviour_cb (GtkWidget *w, tilda_window *tw
     config_setint ("non_focus_pull_up_behaviour", status);
 }
 
-static void combo_tab_pos_changed_cb (GtkWidget *w, tilda_window *tw)
-{
-    const gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
-    const GtkPositionType positions[] = {
-                             GTK_POS_TOP,
-                             GTK_POS_BOTTOM,
-                             GTK_POS_LEFT,
-                             GTK_POS_RIGHT };
-
-    if (status < 0 || status > 4) {
-        DEBUG_ERROR ("Notebook tab position invalid");
-        g_printerr (_("Invalid tab position setting, ignoring\n"));
-        return;
-    }
-
-    config_setint ("tab_pos", status);
-
-    if(NB_HIDDEN == status) {
-        gtk_notebook_set_show_tabs (GTK_NOTEBOOK(tw->notebook), FALSE);
-    }
-    else {
-        if (gtk_notebook_get_n_pages(GTK_NOTEBOOK (tw->notebook)) > 1) {
-            gtk_notebook_set_show_tabs(GTK_NOTEBOOK(tw->notebook), TRUE);
-        }
-        gtk_notebook_set_tab_pos (GTK_NOTEBOOK(tw->notebook), positions[status]);
-    }
-}
-
 static void button_font_font_set_cb (GtkWidget *w, tilda_window *tw)
 {
     const gchar *font = gtk_font_button_get_font_name (GTK_FONT_BUTTON (w));
@@ -1263,6 +1235,33 @@ static void spin_y_position_value_changed_cb (GtkWidget *w, tilda_window *tw)
     generate_animation_positions (tw);
 }
 
+static void combo_tab_pos_changed_cb (GtkWidget *w, tilda_window *tw)
+{
+    const gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
+    const GtkPositionType positions[] = {
+                             GTK_POS_TOP,
+                             GTK_POS_BOTTOM,
+                             GTK_POS_LEFT,
+                             GTK_POS_RIGHT };
+
+    if (status < 0 || status > 4) {
+        DEBUG_ERROR ("Notebook tab position invalid");
+        g_printerr (_("Invalid tab position setting, ignoring\n"));
+        return;
+    }
+
+    config_setint ("tab_pos", status);
+
+    if(NB_HIDDEN == status) {
+        gtk_notebook_set_show_tabs (GTK_NOTEBOOK(tw->notebook), FALSE);
+    }
+    else {
+        if (gtk_notebook_get_n_pages(GTK_NOTEBOOK (tw->notebook)) > 1) {
+            gtk_notebook_set_show_tabs(GTK_NOTEBOOK(tw->notebook), TRUE);
+        }
+        gtk_notebook_set_tab_pos (GTK_NOTEBOOK(tw->notebook), positions[status]);
+    }
+}
 
 static void check_enable_transparency_toggled_cb (GtkWidget *w, tilda_window *tw)
 {
@@ -1955,7 +1954,6 @@ static void set_wizard_state_from_config (tilda_window *tw) {
 
     CHECK_BUTTON ("check_enable_antialiasing", "antialias");
     CHECK_BUTTON ("check_allow_bold_text", "bold");
-    COMBO_BOX ("combo_tab_pos", "tab_pos");
     FONT_BUTTON ("button_font", "font");
 
     SPIN_BUTTON_SET_RANGE ("spin_auto_hide_time", 0, 99999);
@@ -1993,6 +1991,8 @@ static void set_wizard_state_from_config (tilda_window *tw) {
     CHECK_BUTTON ("check_animated_pulldown", "animation");
     SPIN_BUTTON ("spin_animation_delay", "slide_sleep_usec");
     COMBO_BOX ("combo_animation_orientation", "animation_orientation");
+
+    COMBO_BOX ("combo_tab_pos", "tab_pos");
 
     SET_SENSITIVE_BY_CONFIG_BOOL ("label_level_of_transparency","enable_transparency");
     SET_SENSITIVE_BY_CONFIG_BOOL ("spin_level_of_transparency","enable_transparency");
@@ -2122,7 +2122,6 @@ static void connect_wizard_signals (TildaWizard *wizard)
 
     CONNECT_SIGNAL ("check_enable_antialiasing","toggled",check_enable_antialiasing_toggled_cb, tw);
     CONNECT_SIGNAL ("check_allow_bold_text","toggled",check_allow_bold_text_toggled_cb, tw);
-    CONNECT_SIGNAL ("combo_tab_pos","changed",combo_tab_pos_changed_cb, tw);
     CONNECT_SIGNAL ("button_font","font-set",button_font_font_set_cb, tw);
 
     CONNECT_SIGNAL ("spin_auto_hide_time","value-changed",spin_auto_hide_time_value_changed_cb, tw);
@@ -2156,6 +2155,8 @@ static void connect_wizard_signals (TildaWizard *wizard)
     CONNECT_SIGNAL ("check_centered_vertically","toggled",check_centered_vertically_toggled_cb, tw);
     CONNECT_SIGNAL ("spin_x_position","value-changed",spin_x_position_value_changed_cb, tw);
     CONNECT_SIGNAL ("spin_y_position","value-changed",spin_y_position_value_changed_cb, tw);
+
+    CONNECT_SIGNAL ("combo_tab_pos","changed",combo_tab_pos_changed_cb, tw);
 
     CONNECT_SIGNAL ("check_enable_transparency","toggled",check_enable_transparency_toggled_cb, tw);
     CONNECT_SIGNAL ("check_animated_pulldown","toggled",check_animated_pulldown_toggled_cb, tw);

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -1263,6 +1263,23 @@ static void combo_tab_pos_changed_cb (GtkWidget *w, tilda_window *tw)
     }
 }
 
+static void check_expand_tabs_toggled_cb (GtkWidget *w, tilda_window *tw)
+{
+    const gboolean status = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(w));
+
+    config_setbool ("expand_tabs", status);
+
+    int page = 0;
+    GtkWidget *child = NULL;
+    while((child = gtk_notebook_get_nth_page(tw->notebook, page++))){
+        gtk_container_child_set (GTK_CONTAINER(tw->notebook),
+            child,
+            "tab-expand", status,
+            "tab-fill", status,
+            NULL);
+    }
+}
+
 static void check_enable_transparency_toggled_cb (GtkWidget *w, tilda_window *tw)
 {
     const gboolean status = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(w));
@@ -1993,6 +2010,7 @@ static void set_wizard_state_from_config (tilda_window *tw) {
     COMBO_BOX ("combo_animation_orientation", "animation_orientation");
 
     COMBO_BOX ("combo_tab_pos", "tab_pos");
+    CHECK_BUTTON ("check_expand_tabs", "expand_tabs");
 
     SET_SENSITIVE_BY_CONFIG_BOOL ("label_level_of_transparency","enable_transparency");
     SET_SENSITIVE_BY_CONFIG_BOOL ("spin_level_of_transparency","enable_transparency");
@@ -2157,6 +2175,7 @@ static void connect_wizard_signals (TildaWizard *wizard)
     CONNECT_SIGNAL ("spin_y_position","value-changed",spin_y_position_value_changed_cb, tw);
 
     CONNECT_SIGNAL ("combo_tab_pos","changed",combo_tab_pos_changed_cb, tw);
+    CONNECT_SIGNAL ("check_expand_tabs","toggled",check_expand_tabs_toggled_cb, tw);
 
     CONNECT_SIGNAL ("check_enable_transparency","toggled",check_enable_transparency_toggled_cb, tw);
     CONNECT_SIGNAL ("check_animated_pulldown","toggled",check_animated_pulldown_toggled_cb, tw);

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -1280,6 +1280,17 @@ static void check_expand_tabs_toggled_cb (GtkWidget *w, tilda_window *tw)
     }
 }
 
+static void check_show_single_tab_toggled_cb (GtkWidget *w, tilda_window *tw)
+{
+    const gboolean status = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(w));
+
+    config_setbool ("show_single_tab", status);
+
+    /* Only need to do something if the current number of tabs is 1 */
+    if (gtk_notebook_get_n_pages (GTK_NOTEBOOK (tw->notebook)) == 1)
+        gtk_notebook_set_show_tabs (GTK_NOTEBOOK (tw->notebook), status);
+}
+
 static void check_enable_transparency_toggled_cb (GtkWidget *w, tilda_window *tw)
 {
     const gboolean status = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(w));
@@ -2011,6 +2022,7 @@ static void set_wizard_state_from_config (tilda_window *tw) {
 
     COMBO_BOX ("combo_tab_pos", "tab_pos");
     CHECK_BUTTON ("check_expand_tabs", "expand_tabs");
+    CHECK_BUTTON ("check_show_single_tab", "show_single_tab");
 
     SET_SENSITIVE_BY_CONFIG_BOOL ("label_level_of_transparency","enable_transparency");
     SET_SENSITIVE_BY_CONFIG_BOOL ("spin_level_of_transparency","enable_transparency");
@@ -2176,6 +2188,7 @@ static void connect_wizard_signals (TildaWizard *wizard)
 
     CONNECT_SIGNAL ("combo_tab_pos","changed",combo_tab_pos_changed_cb, tw);
     CONNECT_SIGNAL ("check_expand_tabs","toggled",check_expand_tabs_toggled_cb, tw);
+    CONNECT_SIGNAL ("check_show_single_tab","toggled",check_show_single_tab_toggled_cb, tw);
 
     CONNECT_SIGNAL ("check_enable_transparency","toggled",check_enable_transparency_toggled_cb, tw);
     CONNECT_SIGNAL ("check_animated_pulldown","toggled",check_animated_pulldown_toggled_cb, tw);


### PR DESCRIPTION
* Moved 'tab position' option to a new Tabs section under Appearance
* Added new options to
  * Expand tabs so they fill available width (similar to gnome-terminal)
  * Added option to show tab bar when only 1 tab