### PR TITLE
New option to always prompt on exit

### DIFF
--- a/src/configsys.c
+++ b/src/configsys.c
@@ -94,6 +94,7 @@ static cfg_opt_t config_opts[] = {
     CFG_INT("timer_resolution", 200, CFGF_NONE),
     CFG_INT("auto_hide_time", 2000, CFGF_NONE),
     CFG_INT("on_last_terminal_exit", 0, CFGF_NONE),
+    CFG_BOOL("prompt_on_exit", FALSE, CFGF_NONE),
     CFG_INT("palette_scheme", 0, CFGF_NONE),
     CFG_INT("non_focus_pull_up_behaviour", 0, CFGF_NONE),
     CFG_INT("cursor_shape", 0, CFGF_NONE),

--- a/src/tilda.ui
+++ b/src/tilda.ui
@@ -935,6 +935,20 @@
                                 <property name="top_attach">0</property>
                               </packing>
                             </child>
+                            <child>
+                              <object class="GtkCheckButton" id="check_prompt_on_exit">
+                                <property name="label" translatable="yes">Always prompt on exit</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="xalign">0</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
                           </object>
                         </child>
                       </object>

--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -835,7 +835,7 @@ menu_quit_cb (GSimpleAction *action,
 {
     DEBUG_FUNCTION ("menu_quit_cb");
 
-    gtk_main_quit ();
+    tilda_window_confirm_quit(TILDA_WINDOW(user_data));
 }
 
 static void

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -681,7 +681,7 @@ static gint tilda_window_setup_keyboard_accelerators (tilda_window *tw)
     tilda_add_config_accelerator_by_path("copy_key",       "<tilda>/context/Copy",              G_CALLBACK(ccopy),                          tw);
     tilda_add_config_accelerator_by_path("paste_key",      "<tilda>/context/Paste",             G_CALLBACK(cpaste),                         tw);
     tilda_add_config_accelerator_by_path("fullscreen_key", "<tilda>/context/Toggle Fullscreen", G_CALLBACK(toggle_fullscreen_cb),           tw);
-    tilda_add_config_accelerator_by_path("quit_key",       "<tilda>/context/Quit",              G_CALLBACK(gtk_main_quit),                  tw);
+    tilda_add_config_accelerator_by_path("quit_key",       "<tilda>/context/Quit",              G_CALLBACK(tilda_window_confirm_quit),      tw);
     tilda_add_config_accelerator_by_path("toggle_transparency_key", "<tilda>/context/Toggle Transparency", G_CALLBACK(toggle_transparency_cb),      tw);
     tilda_add_config_accelerator_by_path("toggle_searchbar_key", "<tilda>/context/Toggle Searchbar", G_CALLBACK(tilda_window_toggle_searchbar),     tw);
 
@@ -1204,4 +1204,29 @@ gint tilda_window_close_tab (tilda_window *tw, gint tab_index, gboolean force_ex
     tilda_term_free (tt);
 
     return GDK_EVENT_STOP;
+}
+
+gint tilda_window_confirm_quit (tilda_window *tw)
+{
+    DEBUG_FUNCTION(__FUNCTION__);
+    gint result = GTK_RESPONSE_YES;
+    if(config_getbool("prompt_on_exit"))
+    {
+        GtkDialog *dialog = gtk_message_dialog_new (GTK_WINDOW(tw->window),
+            GTK_DIALOG_DESTROY_WITH_PARENT,
+            GTK_MESSAGE_QUESTION,
+            GTK_BUTTONS_YES_NO,
+            "Are you sure you want to Quit?");
+        result = gtk_dialog_run (GTK_DIALOG (dialog));
+        gtk_widget_destroy (dialog);
+    }
+
+    switch (result)
+    {
+        case GTK_RESPONSE_YES:
+            gtk_main_quit ();
+            break;
+        default:
+            break;
+    }
 }

--- a/src/tilda_window.h
+++ b/src/tilda_window.h
@@ -200,6 +200,11 @@ void tilda_window_refresh_transparency(tilda_window *tw);
  */
 gint tilda_window_toggle_searchbar (tilda_window *tw);
 
+/**
+ * Show confirm dialog before quitting (if enabled)
+ */
+gint tilda_window_confirm_quit (tilda_window *tw);
+
 #define TILDA_WINDOW(data) ((tilda_window *)(data))
 
 /* Allow scales a bit smaller and a bit larger than the usual pango ranges */

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -993,6 +993,13 @@ static void combo_on_last_terminal_exit_changed_cb (GtkWidget *w, tilda_window *
     config_setint ("on_last_terminal_exit", status);
 }
 
+static void check_prompt_on_exit_toggled_cb (GtkWidget *w, tilda_window *tw)
+{
+    const gboolean prompt_on_exit = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w));
+
+    config_setbool("prompt_on_exit", prompt_on_exit);
+}
+
 static void entry_web_browser_changed (GtkWidget *w, tilda_window *tw) {
     const gchar *web_browser = gtk_entry_get_text (GTK_ENTRY(w));
 
@@ -1978,6 +1985,7 @@ static void set_wizard_state_from_config (tilda_window *tw) {
     CHECK_BUTTON ("check_command_login_shell", "command_login_shell");
     COMBO_BOX ("combo_command_exit", "command_exit");
     COMBO_BOX ("combo_on_last_terminal_exit", "on_last_terminal_exit");
+    CHECK_BUTTON ("check_prompt_on_exit", "prompt_on_exit");
     SET_SENSITIVE_BY_CONFIG_BOOL ("entry_custom_command","run_command");
     SET_SENSITIVE_BY_CONFIG_BOOL ("label_custom_command", "run_command");
 
@@ -2130,6 +2138,7 @@ static void connect_wizard_signals (TildaWizard *wizard)
     CONNECT_SIGNAL ("check_auto_hide_on_mouse_leave","toggled",check_auto_hide_on_mouse_leave_toggled_cb, tw);
 
     CONNECT_SIGNAL ("combo_on_last_terminal_exit","changed",combo_on_last_terminal_exit_changed_cb, tw);
+    CONNECT_SIGNAL ("check_prompt_on_exit","toggled",check_prompt_on_exit_toggled_cb, tw);
 
     /* Title and Command Tab */
     CONNECT_SIGNAL ("entry_title","changed",entry_title_changed_cb, tw);


### PR DESCRIPTION
Shows a Yes/No dialog before quitting, if configured. Defaults to off for existing behaviour.