### PR TITLE
Make title_max_length_flag a combo to specify how to trim title

### DIFF
--- a/src/configsys.c
+++ b/src/configsys.c
@@ -100,6 +100,7 @@ static cfg_opt_t config_opts[] = {
 
     /* Deprecated tilda options */
     CFG_INT("show_on_monitor_number", 0, CFGF_NODEFAULT),
+    CFG_BOOL("title_max_length_flag", TRUE, CFGF_NONE),
     /* End deprecated tilda options */
 
     /* The length of a tab title */
@@ -161,8 +162,8 @@ static cfg_opt_t config_opts[] = {
     CFG_BOOL("double_buffer", FALSE, CFGF_NONE),
     CFG_BOOL("auto_hide_on_focus_lost", FALSE, CFGF_NONE),
     CFG_BOOL("auto_hide_on_mouse_leave", FALSE, CFGF_NONE),
-    /* Whether we limit the length of a tab title */
-    CFG_BOOL("title_max_length_flag", TRUE, CFGF_NONE),
+    /* Whether and how we limit the length of a tab title */
+    CFG_INT("title_behaviour", 2, CFGF_NONE),
     /* Whether to set a new tab's working dir to the current tab's */
     CFG_BOOL("inherit_working_dir", TRUE, CFGF_NONE),
     CFG_BOOL("command_login_shell", FALSE, CFGF_NONE),
@@ -417,7 +418,7 @@ gint config_init (const gchar *config_file)
      * This is a lame work around until we get a permenant solution to
      * libconfuse lacking for this functionality
      */
-    const gchar *deprecated_tilda_config_options[] = {"show_on_monitor_number"};
+    const gchar *deprecated_tilda_config_options[] = {"show_on_monitor_number","title_max_length_flag"};
     remove_deprecated_config_options(deprecated_tilda_config_options, G_N_ELEMENTS(deprecated_tilda_config_options));
 
 #if VTE_MINOR_VERSION >= 40

--- a/src/tilda.ui
+++ b/src/tilda.ui
@@ -278,6 +278,23 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="model12">
+    <columns>
+      <!-- column-name gchararray -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Show whole tab title</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Show first n chars of title</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Show last n chars of title</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkListStore" id="monitor_list_store">
     <columns>
       <!-- column-name monitor_plug_name -->
@@ -1172,6 +1189,18 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkLabel" id="label_title_max_length">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Title Max Length:</property>
+                                <property name="xalign">1</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">3</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkSpinButton" id="spin_title_max_length">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
@@ -1180,7 +1209,7 @@
                               </object>
                               <packing>
                                 <property name="left_attach">1</property>
-                                <property name="top_attach">2</property>
+                                <property name="top_attach">3</property>
                               </packing>
                             </child>
                             <child>
@@ -1213,24 +1242,31 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkAlignment" id="alignment39">
+                              <object class="GtkLabel" id="label_title_behaviour">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Title Behaviour:</property>
                                 <property name="xalign">1</property>
-                                <property name="xscale">0</property>
-                                <child>
-                                  <object class="GtkCheckButton" id="check_title_max_length">
-                                    <property name="label" translatable="yes">Limit maximum length of tab title:</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="xalign">0</property>
-                                    <property name="draw_indicator">True</property>
-                                  </object>
-                                </child>
                               </object>
                               <packing>
                                 <property name="left_attach">0</property>
+                                <property name="top_attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="combo_title_behaviour">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="model">model12</property>
+                                <child>
+                                  <object class="GtkCellRendererText" id="renderer18"/>
+                                  <attributes>
+                                    <attribute name="text">0</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
                                 <property name="top_attach">2</property>
                               </packing>
                             </child>

--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -254,10 +254,16 @@ static void window_title_changed_cb (GtkWidget *widget, gpointer data)
     }
 
     guint length = (guint) config_getint ("title_max_length");
-
-    if(config_getbool("title_max_length_flag") && strlen(title) > length) {
-        gchar *titleOffset = title + strlen(title) - length;
-        gchar *shortTitle = g_strdup_printf ("...%s", titleOffset);
+    guint title_behaviour = config_getint("title_behaviour");
+    if(title_behaviour && strlen(title) > length) {
+        gchar *shortTitle = NULL;
+        if(title_behaviour == 1) {
+            shortTitle = g_strdup_printf ("%.*s...", length, title);
+        }
+        else {
+            gchar *titleOffset = title + strlen(title) - length;
+            shortTitle = g_strdup_printf ("...%s", titleOffset);
+        }
         gtk_label_set_text (GTK_LABEL(label), shortTitle);
         if (active) {
             gtk_window_set_title (GTK_WINDOW (tt->tw->window), shortTitle);

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -563,10 +563,16 @@ static void window_title_change_all (tilda_window *tw)
         label = gtk_notebook_get_tab_label (GTK_NOTEBOOK (tw->notebook), page);
 
         guint length = config_getint ("title_max_length");
-
-        if(config_getbool("title_max_length_flag") && strlen(title) > length) {
-            gchar *titleOffset = title + strlen(title) - length;
-            gchar *shortTitle = g_strdup_printf ("...%s", titleOffset);
+        guint title_behaviour = config_getint("title_behaviour");
+        if(title_behaviour && strlen(title) > length) {
+            gchar *shortTitle = NULL;
+            if(title_behaviour == 1) {
+                shortTitle = g_strdup_printf ("%.*s...", length, title);
+            }
+            else {
+                gchar *titleOffset = title + strlen(title) - length;
+                shortTitle = g_strdup_printf ("...%s", titleOffset);
+            }
             gtk_label_set_text (GTK_LABEL(label), shortTitle);
             g_free(shortTitle);
         } else {
@@ -871,19 +877,19 @@ static void combo_dynamically_set_title_changed_cb (GtkWidget *w, tilda_window *
     window_title_change_all (tw);
 }
 
-static void check_max_title_length_cb (GtkWidget *w, tilda_window *tw)
+static void combo_title_behaviour_changed_cb (GtkWidget *w, tilda_window *tw)
 {
-    DEBUG_FUNCTION ("check_max_title_length_cb");
+    DEBUG_FUNCTION ("combo_title_behaviour_changed_cb");
 
     GtkWidget *entry = GTK_WIDGET(
         gtk_builder_get_object (xml, ("spin_title_max_length"))
     );
-    if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w))) {
-        config_setbool("title_max_length_flag", TRUE);
-        gtk_editable_set_editable (GTK_EDITABLE(entry), TRUE);
+    const gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
+    config_setint("title_behaviour", status);
+    if (status > 0) {
+        gtk_widget_set_sensitive (entry, TRUE);
     } else {
-        config_setbool("title_max_length_flag", FALSE);
-        gtk_editable_set_editable (GTK_EDITABLE(entry), FALSE);
+        gtk_widget_set_sensitive (entry, FALSE);
     }
 }
 
@@ -1967,11 +1973,10 @@ static void set_wizard_state_from_config (tilda_window *tw) {
     TEXT_ENTRY ("entry_title", "title");
     COMBO_BOX ("combo_dynamically_set_title", "d_set_title");
     // Whether to limit the length of the title
-    CHECK_BUTTON ("check_title_max_length", "title_max_length_flag");
+    COMBO_BOX ("combo_title_behaviour", "title_behaviour");
     // The maximum length of the title
     SPIN_BUTTON_SET_RANGE ("spin_title_max_length", 0, 99999);
     SPIN_BUTTON_SET_VALUE ("spin_title_max_length", config_getint ("title_max_length"));
-    SET_SENSITIVE_BY_CONFIG_BOOL ("spin_title_max_length", "title_max_length_flag");
 
     CHECK_BUTTON ("check_run_custom_command", "run_command");
     TEXT_ENTRY ("entry_custom_command", "command");
@@ -2134,7 +2139,7 @@ static void connect_wizard_signals (TildaWizard *wizard)
     /* Title and Command Tab */
     CONNECT_SIGNAL ("entry_title","changed",entry_title_changed_cb, tw);
     CONNECT_SIGNAL ("combo_dynamically_set_title","changed",combo_dynamically_set_title_changed_cb, tw);
-    CONNECT_SIGNAL ("check_title_max_length","toggled",check_max_title_length_cb, tw);
+    CONNECT_SIGNAL ("combo_title_behaviour","changed",combo_title_behaviour_changed_cb, tw);
     CONNECT_SIGNAL ("spin_title_max_length","value-changed", spin_max_title_length_changed_cb, tw);
 
     CONNECT_SIGNAL ("check_run_custom_command","toggled",check_run_custom_command_toggled_cb, tw);


### PR DESCRIPTION
The options being
* not at all
* show first n chars
* show last n chars (default as per previous behaviour)


Personally, I prefer to trim the end off the command as the tabs are generally tmux sessions with the session name at the start of the title. This change allows for that, or either of the existing options