### PR TITLE
Update translation config; Finish Simplified Chinese translation

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -4,6 +4,7 @@ src/menu.ui
 src/tilda.ui
 src/configsys.c
 src/tilda.c
+src/tilda-keybinding.c
 src/tilda_terminal.c
 src/tilda_window.c
 src/wizard.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,5 +1,6 @@
 # List of source files which contain translatable strings.
 
+src/menu.ui
 src/tilda.ui
 src/configsys.c
 src/tilda.c

--- a/po/README
+++ b/po/README
@@ -1,11 +1,11 @@
 New Translations
 ================================================================================
-We, the Tilda developers, have decided to use Launchpad to assist with our
-translation effort. Please use it if you can. It is located at
+We, the Tilda developers, have stopped using Launchpad to assist with our
+translation effort. It was located at
 https://translations.launchpad.net/tilda/trunk/+pots/tilda
 
-We would appreciate if you do translations on Launchpad to save yourself and
-others from unneeded effort.
+Please directly submit Pull Requests on GitHub to update translations or
+initialize new translation.
 
 
 How to integrate a new translation into Tilda
@@ -30,6 +30,11 @@ msginit -l en_US         # (for USA English. Creates en.po)
 # extension.
 #
 # That would be "en" for the above examples
+#
+# If po/Makefile does not exist, please configure this project first:
+#
+# autoreconf --install --verbose --force
+# ./configure
 
 Then run the following commands:
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2014-07-30 22:44+0000\n"
 "Last-Translator: Anton Antonov <syndbe@gmail.com>\n"
 "Language-Team: Bulgarian <bg@li.org>\n"
@@ -17,6 +17,38 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2014-07-30 22:48+0000\n"
 "X-Generator: Launchpad (build 17131)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr "_Нов подпрозорец"
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr "_Затвори подпрозорец"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 #, fuzzy
@@ -31,19 +63,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -73,84 +105,96 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
+msgid "Show whole tab title"
 msgstr ""
 
 #: src/tilda.ui:143
-msgid "Goes after initial title"
+msgid "Show first n chars of title"
 msgstr ""
 
 #: src/tilda.ui:146
+msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
 msgid "Goes before initial title"
 msgstr ""
 
-#: src/tilda.ui:149
+#: src/tilda.ui:166
 #, fuzzy
 msgid "Replace initial title"
 msgstr "Първоначално Заглавие:"
 
-#: src/tilda.ui:160
+#: src/tilda.ui:177
 #, fuzzy
 msgid "Drop to the default shell"
 msgstr "Не може да пусне shell по подразбиране: %s\n"
 
-#: src/tilda.ui:163
+#: src/tilda.ui:180
 msgid "Restart the command"
 msgstr ""
 
-#: src/tilda.ui:166
+#: src/tilda.ui:183
 msgid "Exit the terminal"
 msgstr ""
 
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
 msgid "Custom"
 msgstr ""
 
-#: src/tilda.ui:200
+#: src/tilda.ui:217
 msgid "Green on Black"
 msgstr ""
 
-#: src/tilda.ui:203
+#: src/tilda.ui:220
 msgid "Black on White"
 msgstr ""
 
-#: src/tilda.ui:206
+#: src/tilda.ui:223
 msgid "White on Black"
 msgstr ""
 
-#: src/tilda.ui:209 src/wizard.c:223
+#: src/tilda.ui:226 src/wizard.c:223
 msgid "Zenburn"
 msgstr ""
 
-#: src/tilda.ui:212 src/wizard.c:224
+#: src/tilda.ui:229 src/wizard.c:224
 msgid "Solarized Light"
 msgstr ""
 
-#: src/tilda.ui:215 src/wizard.c:225
+#: src/tilda.ui:232 src/wizard.c:225
 msgid "Solarized Dark"
 msgstr ""
 
-#: src/tilda.ui:218 src/wizard.c:226
+#: src/tilda.ui:235 src/wizard.c:226
 msgid "Snazzy"
 msgstr ""
 
-#: src/tilda.ui:240
+#: src/tilda.ui:257
 msgid "On the Left"
 msgstr ""
 
-#: src/tilda.ui:243
+#: src/tilda.ui:260
 msgid "On the Right"
 msgstr ""
 
-#: src/tilda.ui:246
+#: src/tilda.ui:263
 msgid "Disabled"
 msgstr ""
 
-#: src/tilda.ui:257 src/tilda.ui:274
+#: src/tilda.ui:274 src/tilda.ui:291
 msgid "ASCII DEL"
 msgstr ""
 
-#: src/tilda.ui:260 src/tilda.ui:277
+#: src/tilda.ui:277 src/tilda.ui:294
 #, fuzzy
 msgid "Escape sequence"
 msgstr ""
@@ -158,27 +202,15 @@ msgstr ""
 "Escape последователност\n"
 "Control-H"
 
-#: src/tilda.ui:263 src/tilda.ui:280
+#: src/tilda.ui:280 src/tilda.ui:297
 msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
-msgid "Show whole tab title"
-msgstr ""
-
-#: src/tilda.ui:294
-msgid "Show first n chars of title"
-msgstr ""
-
-#: src/tilda.ui:297
-msgid "Show last n chars of title"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr "Tilda конфигурация"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Стартирай Tilda скрита"
 
@@ -210,141 +242,137 @@ msgstr ""
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>Прозорец - представяне</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr "Мигащ курсор"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr "Звучен Terminal Bell"
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Терминал - представяне</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "Позволи antialiasing"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "Позволи удебелен текст"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "Шрифт:"
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Шрифт</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr ""
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr ""
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr ""
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 #, fuzzy
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Заглавие</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Винаги най-отгоре"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 #, fuzzy
 msgid "<b>Program Exit</b>"
 msgstr "<b>Позиция</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "Общ"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr ""
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr ""
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 #, fuzzy
 msgid "Web Browser *:"
 msgstr "Уеб Браузър"
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr "<b>Обработка на URL</b>"
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Първоначално Заглавие:"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Динамично зададено Заглавие:"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Заглавие</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr "Пусни произволна команда вместо shell"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "Произволна команда:"
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr "Когато командата приключи:"
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Команда</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -352,264 +380,256 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 #, fuzzy
 msgid "Close Action"
 msgstr "_Затвори подпрозорец"
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Заглавие и команда"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Процент"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "В пиксели"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Височина</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 #, fuzzy
 msgid "<b>Select monitor</b>"
 msgstr "<b>Шрифт</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Широчина</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Центрирана хоризонтално"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Y позиция"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "X позиция"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Центрирана вертикално"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Позиция</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr "Позиция на подпрозорци:"
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Заглавие</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Забавяне на анимацията (usec)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Ориентация на анимацията"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Използвай изображение за фон"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Анимирано падане"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Ниво на прозрачност"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Позволи прозрачност"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Екстри</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Външен вид"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 #, fuzzy
 msgid "Cursor Color"
 msgstr "Мигащ курсор"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "Цвят на текст"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "Цвят на фон"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr "Вградени цветови схеми"
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr "<b>Цветове на преден и заден план</b>"
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 #, fuzzy
 msgid "Built-in schemes:"
 msgstr "Вградени цветови схеми"
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr ""
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 #, fuzzy
 msgid "<b>Palette</b>"
 msgstr "<b>Заглавие</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Цветове"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "Скрол лента е:"
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 #, fuzzy
 msgid "Limit scrollback to:"
 msgstr "Scrollback:"
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "Скрол на извод"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr "Скрол на натискане на бутон"
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "Скрол на фон"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "редове"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>Скролване</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Скролване"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -621,53 +641,53 @@ msgstr ""
 "приложения и операционни системи, които очакват различно терминално "
 "поведение.</i></small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr "_Backspace копчето генерира:"
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr "_Delete копчето генерира:"
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Върни настройките за съвместимост по подразбиране"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>Съвместимост</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Съвместимост"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "Клавишни комбинации"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "Клавишни комбинации"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -689,61 +709,53 @@ msgstr "Не може да запише конфигурационният фа�
 msgid "Unable to run command: `%s'\n"
 msgstr "Не може да изпълни командата:`%s'\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr "Не може да отвори директория: %s\n"
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "Използвай Antialised шрифтове"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Сложи фоннов цвят"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Изпълни команда при стартиране"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Сложи шрифт на следният стринг"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Покажи помощник при конфигурация"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "Scrollback редове"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "Използвай скрол лента"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Принтирай версията и излез"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "Определи началната работна директория"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Определи фонново изображение"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "Непрозрачност: 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "Покажи помощник при конфигурация"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -756,7 +768,7 @@ msgstr ""
 "\n"
 "Грешка: %s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, fuzzy, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -770,30 +782,30 @@ msgstr ""
 "\n"
 "Грешка: %s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 #, fuzzy
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
@@ -801,40 +813,59 @@ msgid ""
 msgstr ""
 "Клавишната комбинация, която избрахте е невалидна. Моля изберете друга."
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+#, fuzzy
+msgid "Action"
+msgstr "_Затвори подпрозорец"
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, fuzzy, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+"Клавишната комбинация, която избрахте е невалидна. Моля изберете друга."
+
+#: src/tilda_terminal.c:397
 #, fuzzy, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr "Проблем при разчитане на : %s\n"
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, fuzzy, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr "Проблем при разчитане на : %s\n"
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr "Пускам вместо това shell по подразбиране\n"
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr "Не може да пусне командата по избор: %s\n"
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr "Не може да пусне shell по подразбиране: %s\n"
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr "Не успя да пусне уеб брайзъра. Командата беше `%s'\n"
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "Неозаглавен"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr "Невалидна стойност за \"d_set_title\" в конфигурационният файл\n"
 
@@ -846,16 +877,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr "Вие имате невалидна tab_pos във вашият конфигурационен файл\n"
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "Не може да зададе икона на tilda: %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "Недостиг на памет, не може да създаде подпрозорец\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -875,22 +906,37 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, fuzzy, c-format
 msgid "Tilda %d Config"
 msgstr "Tilda конфигурация"
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr "Невалидна настройка за позиция на подпрозорци, игнориране\n"
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "Позволи antialiasing"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Използвай изображение за фон"
+
+#~ msgid "Scroll Background"
+#~ msgstr "Скрол на фон"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "Използвай Antialised шрифтове"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Определи фонново изображение"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Позволи двойно буфериране"
@@ -925,12 +971,6 @@ msgstr "Невалидна настройка за позиция на подп�
 #, fuzzy
 #~ msgid "Problem when opening config file\n"
 #~ msgstr "Проблем при разчитане на конфигурационният файл"
-
-#~ msgid "_New Tab"
-#~ msgstr "_Нов подпрозорец"
-
-#~ msgid "_Close Tab"
-#~ msgstr "_Затвори подпрозорец"
 
 #, fuzzy
 #~ msgid ""
@@ -977,12 +1017,6 @@ msgstr "Невалидна настройка за позиция на подп�
 #, fuzzy
 #~ msgid ""
 #~ "The keybinding you chose for \"Copy\" is invalid. Please choose another."
-#~ msgstr ""
-#~ "Клавишната комбинация, която избрахте е невалидна. Моля изберете друга."
-
-#, fuzzy
-#~ msgid ""
-#~ "The keybinding you chose for \"Paste\" is invalid. Please choose another."
 #~ msgstr ""
 #~ "Клавишната комбинация, която избрахте е невалидна. Моля изберете друга."
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2008-01-22 10:08+0000\n"
 "Last-Translator: animarval <animarval@gmail.com>\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -17,6 +17,39 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr ""
+
+#: src/menu.ui:10
+#, fuzzy
+msgid "_Close Tab"
+msgstr "<b>Ordre</b>"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 msgid "Close Tilda"
@@ -30,19 +63,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -71,107 +104,107 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
+msgid "Show whole tab title"
 msgstr ""
 
 #: src/tilda.ui:143
-msgid "Goes after initial title"
+msgid "Show first n chars of title"
 msgstr ""
 
 #: src/tilda.ui:146
+msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
 msgid "Goes before initial title"
 msgstr ""
 
-#: src/tilda.ui:149
+#: src/tilda.ui:166
 #, fuzzy
 msgid "Replace initial title"
 msgstr "Títol Inicial:"
 
-#: src/tilda.ui:160
+#: src/tilda.ui:177
 msgid "Drop to the default shell"
 msgstr ""
 
-#: src/tilda.ui:163
+#: src/tilda.ui:180
 msgid "Restart the command"
 msgstr ""
 
-#: src/tilda.ui:166
+#: src/tilda.ui:183
 msgid "Exit the terminal"
 msgstr ""
 
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
 msgid "Custom"
 msgstr ""
 
-#: src/tilda.ui:200
+#: src/tilda.ui:217
 msgid "Green on Black"
 msgstr ""
 
-#: src/tilda.ui:203
+#: src/tilda.ui:220
 msgid "Black on White"
 msgstr ""
 
-#: src/tilda.ui:206
+#: src/tilda.ui:223
 msgid "White on Black"
 msgstr ""
 
-#: src/tilda.ui:209 src/wizard.c:223
+#: src/tilda.ui:226 src/wizard.c:223
 msgid "Zenburn"
 msgstr ""
 
-#: src/tilda.ui:212 src/wizard.c:224
+#: src/tilda.ui:229 src/wizard.c:224
 msgid "Solarized Light"
 msgstr ""
 
-#: src/tilda.ui:215 src/wizard.c:225
+#: src/tilda.ui:232 src/wizard.c:225
 msgid "Solarized Dark"
 msgstr ""
 
-#: src/tilda.ui:218 src/wizard.c:226
+#: src/tilda.ui:235 src/wizard.c:226
 msgid "Snazzy"
 msgstr ""
 
-#: src/tilda.ui:240
+#: src/tilda.ui:257
 msgid "On the Left"
 msgstr ""
 
-#: src/tilda.ui:243
+#: src/tilda.ui:260
 msgid "On the Right"
 msgstr ""
 
-#: src/tilda.ui:246
+#: src/tilda.ui:263
 msgid "Disabled"
 msgstr ""
 
-#: src/tilda.ui:257 src/tilda.ui:274
+#: src/tilda.ui:274 src/tilda.ui:291
 msgid "ASCII DEL"
 msgstr ""
 
-#: src/tilda.ui:260 src/tilda.ui:277
+#: src/tilda.ui:277 src/tilda.ui:294
 msgid "Escape sequence"
 msgstr ""
 
-#: src/tilda.ui:263 src/tilda.ui:280
+#: src/tilda.ui:280 src/tilda.ui:297
 msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
-msgid "Show whole tab title"
-msgstr ""
-
-#: src/tilda.ui:294
-msgid "Show first n chars of title"
-msgstr ""
-
-#: src/tilda.ui:297
-msgid "Show last n chars of title"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr "Configuració de Tilda"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Inicia Tilda ocultament"
 
@@ -203,140 +236,136 @@ msgstr ""
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr ""
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr ""
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr ""
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr ""
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr ""
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "Permet text en negreta"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr ""
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr ""
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr ""
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr ""
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr ""
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 #, fuzzy
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Títol</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Sempre en primer pla"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 #, fuzzy
 msgid "<b>Program Exit</b>"
 msgstr "<b>Posició</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr ""
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr ""
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr ""
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 msgid "Web Browser *:"
 msgstr ""
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr ""
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Títol Inicial:"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Posar un Títol Dinàmic:"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Títol</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr ""
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "Ordre personalitzada:"
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr ""
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Ordre</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -344,260 +373,252 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 msgid "Close Action"
 msgstr ""
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr ""
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr ""
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr ""
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr ""
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 #, fuzzy
 msgid "<b>Select monitor</b>"
 msgstr "<b>Títol</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr ""
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr ""
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Posició Y"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "Posició X"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Centrat Verticalment"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Posició</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr "Posició de les Pestanyes:"
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Títol</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Retard de l'Animació (usec)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Orientació de l'Animació"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Usar Imatge per al Fons"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Animació del menú desplegable"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Nivell de Transparència"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Habilita la transparència"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr ""
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr ""
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 msgid "Cursor Color"
 msgstr ""
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr ""
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr ""
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr ""
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr ""
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 msgid "Built-in schemes:"
 msgstr ""
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr ""
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 #, fuzzy
 msgid "<b>Palette</b>"
 msgstr "<b>Títol</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr ""
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr ""
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 msgid "Limit scrollback to:"
 msgstr ""
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr ""
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr ""
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr ""
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "línies"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>Desplaçament</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Desplaçament"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -609,53 +630,53 @@ msgstr ""
 "certes aplicacions i sistemes operatius que esperen un comportament diferent "
 "del terminal.</i></small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr ""
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>Compatibilitat</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr ""
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "<b>Posició</b>"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr ""
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -677,60 +698,52 @@ msgstr ""
 msgid "Unable to run command: `%s'\n"
 msgstr "Incapaç d'executar l'ordre: '%s'\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr "Incapaç d'obrir el directori bloquejat: %s\n"
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr ""
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Indicar color del fons"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Executar ordre a l'iniciar"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr ""
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 msgid "Configuration file"
 msgstr ""
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr ""
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr ""
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr ""
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr ""
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr ""
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr ""
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr ""
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -739,7 +752,7 @@ msgid ""
 "Error message: %s\n"
 msgstr ""
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -749,69 +762,86 @@ msgid ""
 "Error message: %s\n"
 msgstr ""
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
 msgstr ""
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+msgid "Action"
+msgstr ""
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+
+#: src/tilda_terminal.c:397
 #, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr ""
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "Sense títol"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr ""
 
@@ -823,16 +853,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr ""
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr ""
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr ""
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -852,22 +882,25 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, fuzzy, c-format
 msgid "Tilda %d Config"
 msgstr "Configuració de Tilda"
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr ""
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Usar Imatge per al Fons"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Permet Double Buffering"
@@ -882,10 +915,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "<b>Quit</b>"
 #~ msgstr "<b>Títol</b>"
-
-#, fuzzy
-#~ msgid "<b>Close Tab</b>"
-#~ msgstr "<b>Ordre</b>"
 
 #, fuzzy
 #~ msgid "<b>Copy</b>"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2008-02-14 07:57+0000\n"
 "Last-Translator: Vojtěch Trefný <vojtech.trefny@gmail.com>\n"
 "Language-Team: Czech <cs@li.org>\n"
@@ -17,6 +17,38 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr "_Nová karta"
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr "_Zavřít kartu"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 #, fuzzy
@@ -31,19 +63,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -73,84 +105,96 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
+msgid "Show whole tab title"
 msgstr ""
 
 #: src/tilda.ui:143
-msgid "Goes after initial title"
+msgid "Show first n chars of title"
 msgstr ""
 
 #: src/tilda.ui:146
+msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
 msgid "Goes before initial title"
 msgstr ""
 
-#: src/tilda.ui:149
+#: src/tilda.ui:166
 #, fuzzy
 msgid "Replace initial title"
 msgstr "Výchozí titulek"
 
-#: src/tilda.ui:160
+#: src/tilda.ui:177
 #, fuzzy
 msgid "Drop to the default shell"
 msgstr "Nemohu spustit výchozí shell: %s\n"
 
-#: src/tilda.ui:163
+#: src/tilda.ui:180
 msgid "Restart the command"
 msgstr ""
 
-#: src/tilda.ui:166
+#: src/tilda.ui:183
 msgid "Exit the terminal"
 msgstr ""
 
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
 msgid "Custom"
 msgstr ""
 
-#: src/tilda.ui:200
+#: src/tilda.ui:217
 msgid "Green on Black"
 msgstr ""
 
-#: src/tilda.ui:203
+#: src/tilda.ui:220
 msgid "Black on White"
 msgstr ""
 
-#: src/tilda.ui:206
+#: src/tilda.ui:223
 msgid "White on Black"
 msgstr ""
 
-#: src/tilda.ui:209 src/wizard.c:223
+#: src/tilda.ui:226 src/wizard.c:223
 msgid "Zenburn"
 msgstr ""
 
-#: src/tilda.ui:212 src/wizard.c:224
+#: src/tilda.ui:229 src/wizard.c:224
 msgid "Solarized Light"
 msgstr ""
 
-#: src/tilda.ui:215 src/wizard.c:225
+#: src/tilda.ui:232 src/wizard.c:225
 msgid "Solarized Dark"
 msgstr ""
 
-#: src/tilda.ui:218 src/wizard.c:226
+#: src/tilda.ui:235 src/wizard.c:226
 msgid "Snazzy"
 msgstr ""
 
-#: src/tilda.ui:240
+#: src/tilda.ui:257
 msgid "On the Left"
 msgstr ""
 
-#: src/tilda.ui:243
+#: src/tilda.ui:260
 msgid "On the Right"
 msgstr ""
 
-#: src/tilda.ui:246
+#: src/tilda.ui:263
 msgid "Disabled"
 msgstr ""
 
-#: src/tilda.ui:257 src/tilda.ui:274
+#: src/tilda.ui:274 src/tilda.ui:291
 msgid "ASCII DEL"
 msgstr ""
 
-#: src/tilda.ui:260 src/tilda.ui:277
+#: src/tilda.ui:277 src/tilda.ui:294
 #, fuzzy
 msgid "Escape sequence"
 msgstr ""
@@ -158,27 +202,15 @@ msgstr ""
 "Escape sekvenci\n"
 "Control-H"
 
-#: src/tilda.ui:263 src/tilda.ui:280
+#: src/tilda.ui:280 src/tilda.ui:297
 msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
-msgid "Show whole tab title"
-msgstr ""
-
-#: src/tilda.ui:294
-msgid "Show first n chars of title"
-msgstr ""
-
-#: src/tilda.ui:297
-msgid "Show last n chars of title"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr "Konfigurace"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Spustit Tildu skrytou"
 
@@ -210,141 +242,137 @@ msgstr ""
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "Zobrazení okna"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr "Kurzor bliká"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr "Terminálové pípání"
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Zobrazení Terminálu</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "Povolit vyhlazování"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "Povolit tučný text"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "Písmo:"
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Písmo</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr ""
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr ""
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr ""
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 #, fuzzy
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Titulek</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Vždy navrchu"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 #, fuzzy
 msgid "<b>Program Exit</b>"
 msgstr "<b>Umístění</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "Obecné"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr ""
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr ""
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 #, fuzzy
 msgid "Web Browser *:"
 msgstr "Webový prohlížeč"
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr "URL"
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Výchozí titulek"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Dynamický titulek"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Titulek</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr "Místo shellu spustit vlastní příkaz"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "Vlastní příkaz"
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr "Když příkaz skončí"
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Příkaz</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -352,264 +380,256 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 #, fuzzy
 msgid "Close Action"
 msgstr "_Zavřít kartu"
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Titulek a příkaz"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Procenta"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "V pixelech"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Výška</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 #, fuzzy
 msgid "<b>Select monitor</b>"
 msgstr "<b>Titulek</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Šířka</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Vycentrováno vodorovně"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Pozice Y"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "Pozice X"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Vycentrováno svisle"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Umístění</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr "Pozice panelů"
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Titulek</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Délka animace (mikrosekundy)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Směr animace"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Obrázek na pozadí"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Animované vysouvání"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Úroveň průhlednosti"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Povolit průhlednost"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Doplňky</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Vzhled"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 #, fuzzy
 msgid "Cursor Color"
 msgstr "Kurzor bliká"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "Barva textu"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "Barva pozadí"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr "Vestavěná témata"
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr "Barva pozadí a popředí"
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 #, fuzzy
 msgid "Built-in schemes:"
 msgstr "Vestavěná témata"
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr ""
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 #, fuzzy
 msgid "<b>Palette</b>"
 msgstr "<b>Titulek</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Barvy"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "Posuvník je:"
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 #, fuzzy
 msgid "Limit scrollback to:"
 msgstr "Odskrolováno:"
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "Posouvat při výstupu"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr "Posouvat stiskem klávesy"
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "Posouvat pozadí"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "řádky"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>Posun</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Posouvání"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -621,53 +641,53 @@ msgstr ""
 "některé aplikace a operační systémy očekávají jiné chování terminálu.</i></"
 "small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr "Klávesa _Backspace generuje:"
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr "Klávesa _Delete generuje:"
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "Obnovit standardní nastavení pro _kompatibilitu"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>Kompatibilita</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Kompatibilita"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "Klávesové zkratky"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "Klávesové zkratky"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -689,61 +709,53 @@ msgstr "Nemohu zapsat konfigurační soubor do %s\n"
 msgid "Unable to run command: `%s'\n"
 msgstr "Nemohu spustit příkaz: `%s'\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr "Nemohu otevřít adresář: %s\n"
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "Použít vyhlazování písma"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Nastavit barvu pozadí"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Spouštět příkaz při spuštění"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Nastavit písmo na následující řetězec"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Zobrazit konfiguračního průvodce"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "Odskrolovaných řádků"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "Použít posuvník"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Vypsat verzi, poté ukončit"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "Nastavit počáteční pracovní adresář"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Nastavit obrázek pozadí"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "Průhlednost: 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "Zobrazit konfiguračního průvodce"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -756,7 +768,7 @@ msgstr ""
 "\n"
 "Chybová zpráva: %s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, fuzzy, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -770,70 +782,88 @@ msgstr ""
 "\n"
 "Chybová zpráva: %s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 #, fuzzy
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
 msgstr "Vámi zvolená klávesová zkratka je neplatná. Prosím zvolte jinou."
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+#, fuzzy
+msgid "Action"
+msgstr "_Zavřít kartu"
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, fuzzy, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr "Vámi zvolená klávesová zkratka je neplatná. Prosím zvolte jinou."
+
+#: src/tilda_terminal.c:397
 #, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr "Spouštím výchozí shell.\n"
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr "Nemohu spustit příkaz: %s\n"
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr "Nemohu spustit výchozí shell: %s\n"
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr "Selhalo spuštění internetového prohlížeče. Příkaz byl `%s'\n"
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "Bez názvu"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr "Špatná hodnota \"d_set_title\" v konfiguračním souboru.\n"
 
@@ -845,16 +875,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr "Špatná hodnota tab_pos v konfiguračním souboru.\n"
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "Nemohu nastavit ikonu tildy: %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "Nedostatek paměti, nemohu vytvořit panel\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -874,22 +904,37 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, fuzzy, c-format
 msgid "Tilda %d Config"
 msgstr "Konfigurace"
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr "Neplatné nastavení pozice panelu. Ignoruji.\n"
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "Povolit vyhlazování"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Obrázek na pozadí"
+
+#~ msgid "Scroll Background"
+#~ msgstr "Posouvat pozadí"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "Použít vyhlazování písma"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Nastavit obrázek pozadí"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Povolit Double Buffering"
@@ -928,12 +973,6 @@ msgstr "Neplatné nastavení pozice panelu. Ignoruji.\n"
 #, fuzzy
 #~ msgid "Problem when opening config file\n"
 #~ msgstr "Nemohu zavřít konfigurační soubor\n"
-
-#~ msgid "_New Tab"
-#~ msgstr "_Nová karta"
-
-#~ msgid "_Close Tab"
-#~ msgstr "_Zavřít kartu"
 
 #, fuzzy
 #~ msgid ""
@@ -974,11 +1013,6 @@ msgstr "Neplatné nastavení pozice panelu. Ignoruji.\n"
 #, fuzzy
 #~ msgid ""
 #~ "The keybinding you chose for \"Copy\" is invalid. Please choose another."
-#~ msgstr "Vámi zvolená klávesová zkratka je neplatná. Prosím zvolte jinou."
-
-#, fuzzy
-#~ msgid ""
-#~ "The keybinding you chose for \"Paste\" is invalid. Please choose another."
 #~ msgstr "Vámi zvolená klávesová zkratka je neplatná. Prosím zvolte jinou."
 
 #, fuzzy

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2013-07-13 11:12+0000\n"
 "Last-Translator: Christian Weber <Unknown>\n"
 "Language-Team: German <de@li.org>\n"
@@ -17,6 +17,39 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr "_Neuer Tab"
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr "Tab s_chließen"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+#, fuzzy
+msgid "_Toggle Fullscreen"
+msgstr "Vollbild umschalten"
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 msgid "Close Tilda"
@@ -30,19 +63,19 @@ msgstr "Neues Terminal öffnen"
 msgid "Open a new terminal and hide"
 msgstr "Neues Terminal öffnen und ausblenden"
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr "Oben"
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr "Unten"
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr "Links"
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr "Rechts"
 
@@ -72,106 +105,106 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
-msgstr "Nicht angezeigt"
-
-#: src/tilda.ui:143
-msgid "Goes after initial title"
-msgstr "Kommt nach Anfangstitel"
-
-#: src/tilda.ui:146
-msgid "Goes before initial title"
-msgstr "Kommt vor Anfangstitel"
-
-#: src/tilda.ui:149
-msgid "Replace initial title"
-msgstr "Ersetzt Anfangstitel"
-
-#: src/tilda.ui:160
-msgid "Drop to the default shell"
-msgstr "Standard-Shell öffnen"
-
-#: src/tilda.ui:163
-msgid "Restart the command"
-msgstr "Befehl erneut ausführen"
-
-#: src/tilda.ui:166
-msgid "Exit the terminal"
-msgstr "Terminal beenden"
-
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
-msgid "Custom"
-msgstr "Benutzerdefiniert"
-
-#: src/tilda.ui:200
-msgid "Green on Black"
-msgstr "Grün auf Schwarz"
-
-#: src/tilda.ui:203
-msgid "Black on White"
-msgstr "Schwarz auf Weiß"
-
-#: src/tilda.ui:206
-msgid "White on Black"
-msgstr "Weiß auf Schwarz"
-
-#: src/tilda.ui:209 src/wizard.c:223
-msgid "Zenburn"
-msgstr ""
-
-#: src/tilda.ui:212 src/wizard.c:224
-msgid "Solarized Light"
-msgstr ""
-
-#: src/tilda.ui:215 src/wizard.c:225
-msgid "Solarized Dark"
-msgstr ""
-
-#: src/tilda.ui:218 src/wizard.c:226
-msgid "Snazzy"
-msgstr ""
-
-#: src/tilda.ui:240
-msgid "On the Left"
-msgstr "Links"
-
-#: src/tilda.ui:243
-msgid "On the Right"
-msgstr "Rechts"
-
-#: src/tilda.ui:246
-msgid "Disabled"
-msgstr "Deaktiviert"
-
-#: src/tilda.ui:257 src/tilda.ui:274
-msgid "ASCII DEL"
-msgstr ""
-
-#: src/tilda.ui:260 src/tilda.ui:277
-msgid "Escape sequence"
-msgstr "Escape-Sequenz"
-
-#: src/tilda.ui:263 src/tilda.ui:280
-msgid "Control-H"
-msgstr "Strg-H"
-
-#: src/tilda.ui:291
 msgid "Show whole tab title"
 msgstr ""
 
-#: src/tilda.ui:294
+#: src/tilda.ui:143
 msgid "Show first n chars of title"
 msgstr ""
 
-#: src/tilda.ui:297
+#: src/tilda.ui:146
 msgid "Show last n chars of title"
 msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr "Nicht angezeigt"
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr "Kommt nach Anfangstitel"
+
+#: src/tilda.ui:163
+msgid "Goes before initial title"
+msgstr "Kommt vor Anfangstitel"
+
+#: src/tilda.ui:166
+msgid "Replace initial title"
+msgstr "Ersetzt Anfangstitel"
+
+#: src/tilda.ui:177
+msgid "Drop to the default shell"
+msgstr "Standard-Shell öffnen"
+
+#: src/tilda.ui:180
+msgid "Restart the command"
+msgstr "Befehl erneut ausführen"
+
+#: src/tilda.ui:183
+msgid "Exit the terminal"
+msgstr "Terminal beenden"
+
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+#: src/tilda.ui:217
+msgid "Green on Black"
+msgstr "Grün auf Schwarz"
+
+#: src/tilda.ui:220
+msgid "Black on White"
+msgstr "Schwarz auf Weiß"
+
+#: src/tilda.ui:223
+msgid "White on Black"
+msgstr "Weiß auf Schwarz"
+
+#: src/tilda.ui:226 src/wizard.c:223
+msgid "Zenburn"
+msgstr ""
+
+#: src/tilda.ui:229 src/wizard.c:224
+msgid "Solarized Light"
+msgstr ""
+
+#: src/tilda.ui:232 src/wizard.c:225
+msgid "Solarized Dark"
+msgstr ""
+
+#: src/tilda.ui:235 src/wizard.c:226
+msgid "Snazzy"
+msgstr ""
+
+#: src/tilda.ui:257
+msgid "On the Left"
+msgstr "Links"
+
+#: src/tilda.ui:260
+msgid "On the Right"
+msgstr "Rechts"
+
+#: src/tilda.ui:263
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: src/tilda.ui:274 src/tilda.ui:291
+msgid "ASCII DEL"
+msgstr ""
+
+#: src/tilda.ui:277 src/tilda.ui:294
+msgid "Escape sequence"
+msgstr "Escape-Sequenz"
+
+#: src/tilda.ui:280 src/tilda.ui:297
+msgid "Control-H"
+msgstr "Strg-H"
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr "Tilda Konfiguration"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Tilda versteckt starten"
 
@@ -204,72 +237,68 @@ msgstr "Vollbild umschalten"
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>Fenster-Anzeige</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr "blinkender Cursor"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr "Akkustische Terminalglocke"
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Terminal-Anzeige</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "Antialiasing aktivieren"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "Fetten Text erlauben"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "Schriftart:"
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Schriftart</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr "Ausblenden, wenn Maus Tilda verlässt"
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr "Ausblendeverzögerung"
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr "Ausblenden, wenn Tilda Fokus verliert"
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Automatisches Ausblenden</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr "Wenn letztes Terminal geschlossen wurde:"
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Im Vordergrund"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 msgid "<b>Program Exit</b>"
 msgstr "<b>Beenden</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
@@ -277,67 +306,67 @@ msgstr ""
 "<small><i><b>Hinweis</b>: Manche Optionen erfordern einen Neustart von tilda."
 "</i></small>"
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "Allgemein"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr "Wortzeichen"
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr "<b>Wörter auswählen</b>"
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 msgid "Web Browser *:"
 msgstr "Webbrowser *:"
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr "<b>URL-Handhabung</b>"
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Anfangsüberschrift:"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Dynamische Überschrift:"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Titel</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr "Führe benutzerdefinierten Befehl anstelle der Shell aus"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "Benutzerdefinierter Befehl:"
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr "Wenn Befehl endet:"
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Befehl</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -349,134 +378,130 @@ msgstr ""
 "allgemeinen Befehle 'x-www-browser' und 'xdg-open' sind möglich. Der beste "
 "Befehl kann je nach System unterschiedlich sein."
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 #, fuzzy
 msgid "Close Action"
 msgstr "Tilda Beenden"
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Titel und Befehl"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Prozentanteil"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "In Pixel"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Höhe</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 msgid "<b>Select monitor</b>"
 msgstr "<b>Monitor auswählen</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Breite</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Horizontal zentriert"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Y Position"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "X Position"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Vertikal zentriert"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Position</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr "Position der Tabs:"
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Tab hinzufügen</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Verzögerte Animation (µsec)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Animationsorientierung"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Hintergrundbild verwenden"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Pulldown animieren"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Transparenzstufe"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Transparenz aktivieren"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Extras</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Darstellung"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 #, fuzzy
 msgid "Cursor Color"
 msgstr "blinkender Cursor"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "Textfarbe"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "Hintergrundfarbe"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr "Eingebaute Schemata"
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr "<b>Vordergrund- und Hintergrundfarbe</b>"
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
@@ -484,128 +509,124 @@ msgstr ""
 "<small><i><b>Hinweis:</b> Textbasierte Anwendungen können diese Farben "
 "nutzen.</i></small>"
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 msgid "Built-in schemes:"
 msgstr "Eingebaute Schemata:"
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr "Farbpalette:"
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 msgid "<b>Palette</b>"
 msgstr "<b>Palette</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Farben"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "Scrollbalken ist:"
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 #, fuzzy
 msgid "Limit scrollback to:"
 msgstr "Gespeicherte Zeilen:"
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "Ausgabe scrollen"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr "Bei Tastendruck scrollen"
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "Hintergrund scrollen"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "Zeilen"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>Scrollen</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Scrollen"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -617,53 +638,53 @@ msgstr ""
 "Verfügung, damit problematische Anwendungen oder Betriebssysteme reibungslos "
 "funktionieren, die ein anderes Terminal-Verhalten erwarten.</i></small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr "_Rücktaste erzeugt:"
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr "_Entfernen-Taste erzeugt:"
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "Kompatibilitätseinstellungen auf Vorgabewerte _zurücksetzen"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>Kompatibilität</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Kompatibilität"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "Tastenbelegungen"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "Tastenbelegungen"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -685,61 +706,53 @@ msgstr "Kann die Konfigurationsdatei nicht nach %s schreiben\n"
 msgid "Unable to run command: `%s'\n"
 msgstr "Kann Befehl nicht ausführen: `%s'\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr "Kann Lock-Verzeichnis nicht öffnen: %s\n"
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "Zeichensatz mit Antialiasing verwenden"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Hintergrundfarbe auswählen"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Befehl beim Starten ausführen"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Setze die Schriftart auf folgenden String"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Konfigurationsassistenten starten"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "Zurückscrollbare Zeilen"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "Scrollbalken benutzen"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Version ausgeben, danach beenden"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "Startverzeichnis setzen"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Hintergrundbild festlegen"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "Transparenz: 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "Konfigurationsassistenten starten"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -752,7 +765,7 @@ msgstr ""
 "\n"
 "Fehlermeldung: %s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, fuzzy, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -766,31 +779,31 @@ msgstr ""
 "\n"
 "Fehlermeldung: %s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr "Erstelle Verzeichnis: '%s'\n"
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 "style.css in Nutzer Config-Verzeichnis gefunden, nutze Nutzer css style.\n"
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr "Verschiebe altes Konfigurationsverzeichnis in XDG-Verzeichnisse\n"
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
@@ -798,40 +811,60 @@ msgstr ""
 "Das von Ihnen gewählte Tastenkürzel für \"Terminal Einblenden\" ist "
 "ungültig. Bitte wählen Sie ein Anderes."
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+#, fuzzy
+msgid "Action"
+msgstr "Tilda Beenden"
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr "Tastenkürzel eingeben"
+
+#: src/tilda-keybinding.c:417
+#, fuzzy, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+"Das von Ihnen gewählte Tastenkürzel für \"Einfügen\" ist ungültig. Bitte "
+"wählen Sie ein Anderes."
+
+#: src/tilda_terminal.c:397
 #, fuzzy, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr "Problem beim Lesen eines benutzerdefinierten Befehls: %s\n"
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr "Problem beim Lesen eines benutzerdefinierten Befehls: %s\n"
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr "Öffne stattdessen die Standard-Shell\n"
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr "Konnte benutzerdefinierten Befehl nicht ausführen: %s\n"
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr "Konnte die Standard-Shell nicht öffnen: %s\n"
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr "Konnte Webbrowser nicht starten. Der Befehl lautete `%s'\n"
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "Unbenannt"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr "Ungültiger Wert für \"d_set_title\" in der Konfigurationsdatei\n"
 
@@ -843,16 +876,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr "Die Konfigurationsdatei enthält eine falsche tab_pos\n"
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "Kann Tildas Symbol nicht festlegen: %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "Kein Speicher vorhanden, Tab kann nicht erstellt werden\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -872,22 +905,37 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, c-format
 msgid "Tilda %d Config"
 msgstr "Tilda %d Konfiguration"
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr "Ungültige Einstellung der Tab-Position. Ignoriere.\n"
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "Antialiasing aktivieren"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Hintergrundbild verwenden"
+
+#~ msgid "Scroll Background"
+#~ msgstr "Hintergrund scrollen"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "Zeichensatz mit Antialiasing verwenden"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Hintergrundbild festlegen"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Double Buffering aktivieren"
@@ -952,10 +1000,6 @@ msgstr "Ungültige Einstellung der Tab-Position. Ignoriere.\n"
 #~ msgid "<b>Move Tab Right</b>"
 #~ msgstr "<b>Bewege Tab nach rechts</b>"
 
-#, fuzzy
-#~ msgid "<b>Toggle Fullscreen</b>"
-#~ msgstr "Vollbild umschalten"
-
 #~ msgid "Problem when opening config file\n"
 #~ msgstr "Problem beim Öffnen der Konfigurationsdatei\n"
 
@@ -963,12 +1007,6 @@ msgstr "Ungültige Einstellung der Tab-Position. Ignoriere.\n"
 #~ msgstr ""
 #~ "Ein unerwarteter Fehler ist beim Lesen der Konfigurationsdatei "
 #~ "aufgetreten\n"
-
-#~ msgid "_New Tab"
-#~ msgstr "_Neuer Tab"
-
-#~ msgid "_Close Tab"
-#~ msgstr "Tab s_chließen"
 
 #~ msgid ""
 #~ "The keybinding you chose for \"Add Tab\" is invalid. Please choose "
@@ -1016,12 +1054,6 @@ msgstr "Ungültige Einstellung der Tab-Position. Ignoriere.\n"
 #~ "The keybinding you chose for \"Copy\" is invalid. Please choose another."
 #~ msgstr ""
 #~ "Das von Ihnen gewählte Tastenkürzel für \"Kopieren\" ist ungültig. Bitte "
-#~ "wählen Sie ein Anderes."
-
-#~ msgid ""
-#~ "The keybinding you chose for \"Paste\" is invalid. Please choose another."
-#~ msgstr ""
-#~ "Das von Ihnen gewählte Tastenkürzel für \"Einfügen\" ist ungültig. Bitte "
 #~ "wählen Sie ein Anderes."
 
 #~ msgid ""
@@ -1107,9 +1139,6 @@ msgstr "Ungültige Einstellung der Tab-Position. Ignoriere.\n"
 #~ msgstr ""
 #~ "Das von Ihnen gewählte Tastenkürzel für \"Einfügen\" ist ungültig. Bitte "
 #~ "wählen Sie ein Anderes."
-
-#~ msgid "Enter keyboard shortcut"
-#~ msgstr "Tastenkürzel eingeben"
 
 #~ msgid "Problem while parsing config file\n"
 #~ msgstr "Problem beim Lesen der Konfigurationsdatei\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2007-11-13 19:28+0000\n"
 "Last-Translator: Alexander Kikis <kikisalex@hotmail.com>\n"
 "Language-Team: Greek, Modern (1453-) <el@li.org>\n"
@@ -17,6 +17,38 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr ""
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr ""
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 msgid "Close Tilda"
@@ -30,19 +62,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -71,106 +103,106 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
-msgstr ""
-
-#: src/tilda.ui:143
-msgid "Goes after initial title"
-msgstr ""
-
-#: src/tilda.ui:146
-msgid "Goes before initial title"
-msgstr ""
-
-#: src/tilda.ui:149
-msgid "Replace initial title"
-msgstr ""
-
-#: src/tilda.ui:160
-msgid "Drop to the default shell"
-msgstr ""
-
-#: src/tilda.ui:163
-msgid "Restart the command"
-msgstr ""
-
-#: src/tilda.ui:166
-msgid "Exit the terminal"
-msgstr ""
-
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
-msgid "Custom"
-msgstr ""
-
-#: src/tilda.ui:200
-msgid "Green on Black"
-msgstr ""
-
-#: src/tilda.ui:203
-msgid "Black on White"
-msgstr ""
-
-#: src/tilda.ui:206
-msgid "White on Black"
-msgstr ""
-
-#: src/tilda.ui:209 src/wizard.c:223
-msgid "Zenburn"
-msgstr ""
-
-#: src/tilda.ui:212 src/wizard.c:224
-msgid "Solarized Light"
-msgstr ""
-
-#: src/tilda.ui:215 src/wizard.c:225
-msgid "Solarized Dark"
-msgstr ""
-
-#: src/tilda.ui:218 src/wizard.c:226
-msgid "Snazzy"
-msgstr ""
-
-#: src/tilda.ui:240
-msgid "On the Left"
-msgstr ""
-
-#: src/tilda.ui:243
-msgid "On the Right"
-msgstr ""
-
-#: src/tilda.ui:246
-msgid "Disabled"
-msgstr ""
-
-#: src/tilda.ui:257 src/tilda.ui:274
-msgid "ASCII DEL"
-msgstr ""
-
-#: src/tilda.ui:260 src/tilda.ui:277
-msgid "Escape sequence"
-msgstr ""
-
-#: src/tilda.ui:263 src/tilda.ui:280
-msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
 msgid "Show whole tab title"
 msgstr ""
 
-#: src/tilda.ui:294
+#: src/tilda.ui:143
 msgid "Show first n chars of title"
 msgstr ""
 
-#: src/tilda.ui:297
+#: src/tilda.ui:146
 msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
+msgid "Goes before initial title"
+msgstr ""
+
+#: src/tilda.ui:166
+msgid "Replace initial title"
+msgstr ""
+
+#: src/tilda.ui:177
+msgid "Drop to the default shell"
+msgstr ""
+
+#: src/tilda.ui:180
+msgid "Restart the command"
+msgstr ""
+
+#: src/tilda.ui:183
+msgid "Exit the terminal"
+msgstr ""
+
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
+msgid "Custom"
+msgstr ""
+
+#: src/tilda.ui:217
+msgid "Green on Black"
+msgstr ""
+
+#: src/tilda.ui:220
+msgid "Black on White"
+msgstr ""
+
+#: src/tilda.ui:223
+msgid "White on Black"
+msgstr ""
+
+#: src/tilda.ui:226 src/wizard.c:223
+msgid "Zenburn"
+msgstr ""
+
+#: src/tilda.ui:229 src/wizard.c:224
+msgid "Solarized Light"
+msgstr ""
+
+#: src/tilda.ui:232 src/wizard.c:225
+msgid "Solarized Dark"
+msgstr ""
+
+#: src/tilda.ui:235 src/wizard.c:226
+msgid "Snazzy"
+msgstr ""
+
+#: src/tilda.ui:257
+msgid "On the Left"
+msgstr ""
+
+#: src/tilda.ui:260
+msgid "On the Right"
+msgstr ""
+
+#: src/tilda.ui:263
+msgid "Disabled"
+msgstr ""
+
+#: src/tilda.ui:274 src/tilda.ui:291
+msgid "ASCII DEL"
+msgstr ""
+
+#: src/tilda.ui:277 src/tilda.ui:294
+msgid "Escape sequence"
+msgstr ""
+
+#: src/tilda.ui:280 src/tilda.ui:297
+msgid "Control-H"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr ""
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr ""
 
@@ -202,137 +234,133 @@ msgstr ""
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr ""
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr ""
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr ""
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr ""
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr ""
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr ""
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr ""
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr ""
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr ""
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr ""
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr ""
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 msgid "<b>Auto Hide</b>"
 msgstr ""
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 msgid "Always prompt on exit"
 msgstr ""
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 msgid "<b>Program Exit</b>"
 msgstr ""
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr ""
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr ""
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr ""
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 msgid "Web Browser *:"
 msgstr ""
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr ""
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr ""
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr ""
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr ""
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr ""
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr ""
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr ""
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr ""
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -340,257 +368,249 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 msgid "Close Action"
 msgstr ""
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr ""
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr ""
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr ""
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr ""
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 msgid "<b>Select monitor</b>"
 msgstr ""
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr ""
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr ""
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Θέση Y"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "Θέση X"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr ""
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr ""
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr ""
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 msgid "<b>Tabs</b>"
 msgstr ""
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr ""
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr ""
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr ""
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr ""
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr ""
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr ""
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr ""
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr ""
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 msgid "Cursor Color"
 msgstr ""
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr ""
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr ""
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr ""
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr ""
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 msgid "Built-in schemes:"
 msgstr ""
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr ""
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr ""
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr ""
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 msgid "Limit scrollback to:"
 msgstr ""
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr ""
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr ""
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr ""
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr ""
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr ""
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr ""
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -598,52 +618,52 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr ""
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr ""
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr ""
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 msgid "<b>Keybindings</b>"
 msgstr ""
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr ""
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -665,67 +685,59 @@ msgstr ""
 msgid "Unable to run command: `%s'\n"
 msgstr ""
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr ""
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr ""
-
-#: src/tilda.c:327
 #, fuzzy
 msgid "Set the background color"
 msgstr "Θέσε το χρώμα στο υπόβαθρο"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 #, fuzzy
 msgid "Run a command at startup"
 msgstr "Τρέξε μια εντολή στο ξεκίνημα"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 #, fuzzy
 msgid "Set the font to the following string"
 msgstr "Θέστε την γραμματοσειρά στην ακόλουθη σειρά"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 msgid "Configuration file"
 msgstr ""
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr ""
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 #, fuzzy
 msgid "Use Scrollbar"
 msgstr "Χρήση Μπάρας Κύλισις"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 #, fuzzy
 msgid "Print the version, then exit"
 msgstr "Τυπώστε την έκδοση, κατόπιν έξοδος"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 #, fuzzy
 msgid "Set Initial Working Directory"
 msgstr "Καθορισμένος αρχικούς καταλογους εργασίας"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr ""
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 #, fuzzy
 msgid "Opaqueness: 0-100%"
 msgstr "Αδιαφάνεια:  0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr ""
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -734,7 +746,7 @@ msgid ""
 "Error message: %s\n"
 msgstr ""
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -744,69 +756,86 @@ msgid ""
 "Error message: %s\n"
 msgstr ""
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
 msgstr ""
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+msgid "Action"
+msgstr ""
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+
+#: src/tilda_terminal.c:397
 #, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr ""
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr ""
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr ""
 
@@ -818,16 +847,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr ""
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr ""
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr ""
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -847,19 +876,19 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, c-format
 msgid "Tilda %d Config"
 msgstr ""
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2008-01-14 16:23+0000\n"
 "Last-Translator: John Drinkwater <john@nextraweb.com>\n"
 "Language-Team: English (United Kingdom) <en_GB@li.org>\n"
@@ -17,6 +17,39 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr ""
+
+#: src/menu.ui:10
+#, fuzzy
+msgid "_Close Tab"
+msgstr "<b>Command</b>"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 msgid "Close Tilda"
@@ -30,19 +63,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -72,83 +105,95 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
+msgid "Show whole tab title"
 msgstr ""
 
 #: src/tilda.ui:143
-msgid "Goes after initial title"
+msgid "Show first n chars of title"
 msgstr ""
 
 #: src/tilda.ui:146
+msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
 msgid "Goes before initial title"
 msgstr ""
 
-#: src/tilda.ui:149
+#: src/tilda.ui:166
 #, fuzzy
 msgid "Replace initial title"
 msgstr "Initial Title:"
 
-#: src/tilda.ui:160
+#: src/tilda.ui:177
 msgid "Drop to the default shell"
 msgstr ""
 
-#: src/tilda.ui:163
+#: src/tilda.ui:180
 msgid "Restart the command"
 msgstr ""
 
-#: src/tilda.ui:166
+#: src/tilda.ui:183
 msgid "Exit the terminal"
 msgstr ""
 
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
 msgid "Custom"
 msgstr ""
 
-#: src/tilda.ui:200
+#: src/tilda.ui:217
 msgid "Green on Black"
 msgstr ""
 
-#: src/tilda.ui:203
+#: src/tilda.ui:220
 msgid "Black on White"
 msgstr ""
 
-#: src/tilda.ui:206
+#: src/tilda.ui:223
 msgid "White on Black"
 msgstr ""
 
-#: src/tilda.ui:209 src/wizard.c:223
+#: src/tilda.ui:226 src/wizard.c:223
 msgid "Zenburn"
 msgstr ""
 
-#: src/tilda.ui:212 src/wizard.c:224
+#: src/tilda.ui:229 src/wizard.c:224
 msgid "Solarized Light"
 msgstr ""
 
-#: src/tilda.ui:215 src/wizard.c:225
+#: src/tilda.ui:232 src/wizard.c:225
 msgid "Solarized Dark"
 msgstr ""
 
-#: src/tilda.ui:218 src/wizard.c:226
+#: src/tilda.ui:235 src/wizard.c:226
 msgid "Snazzy"
 msgstr ""
 
-#: src/tilda.ui:240
+#: src/tilda.ui:257
 msgid "On the Left"
 msgstr ""
 
-#: src/tilda.ui:243
+#: src/tilda.ui:260
 msgid "On the Right"
 msgstr ""
 
-#: src/tilda.ui:246
+#: src/tilda.ui:263
 msgid "Disabled"
 msgstr ""
 
-#: src/tilda.ui:257 src/tilda.ui:274
+#: src/tilda.ui:274 src/tilda.ui:291
 msgid "ASCII DEL"
 msgstr ""
 
-#: src/tilda.ui:260 src/tilda.ui:277
+#: src/tilda.ui:277 src/tilda.ui:294
 #, fuzzy
 msgid "Escape sequence"
 msgstr ""
@@ -156,27 +201,15 @@ msgstr ""
 "Escape sequence\n"
 "Control-H"
 
-#: src/tilda.ui:263 src/tilda.ui:280
+#: src/tilda.ui:280 src/tilda.ui:297
 msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
-msgid "Show whole tab title"
-msgstr ""
-
-#: src/tilda.ui:294
-msgid "Show first n chars of title"
-msgstr ""
-
-#: src/tilda.ui:297
-msgid "Show last n chars of title"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr "Tilda Config"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Start Tilda hidden"
 
@@ -208,141 +241,137 @@ msgstr ""
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>Window Display</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr "Cursor Blinks"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr "Audible Terminal Bell"
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Terminal Display</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "Enable Anti-aliasing"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "Allow Bold Text"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "Font:"
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Font</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr ""
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr ""
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr ""
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 #, fuzzy
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Title</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Always on top"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 #, fuzzy
 msgid "<b>Program Exit</b>"
 msgstr "<b>Position</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "General"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr ""
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr ""
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 #, fuzzy
 msgid "Web Browser *:"
 msgstr "Web Browser"
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr "<b>URL Handling</b>"
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Initial Title:"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Dynamically-set Title:"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Title</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr "Run a custom command instead of the shell"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "Custom Command:"
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr "When command exits:"
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Command</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -350,263 +379,255 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 msgid "Close Action"
 msgstr ""
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Title and Command"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Percentage"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "In Pixels"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Height</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 #, fuzzy
 msgid "<b>Select monitor</b>"
 msgstr "<b>Title</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Width</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Centred Horizontally"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Y Position"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "X Position"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Centred Vertically"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Position</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr "Position of Tabs:"
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Title</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Animation Delay (usec)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Animation Orientation"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Use Image for Background"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Animated Pull-down"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Level of Transparency"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Enable Transparency"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Extras</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Appearance"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 #, fuzzy
 msgid "Cursor Color"
 msgstr "Cursor Blinks"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "Text Colour"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "Background Colour"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr "Built-in Schemes"
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr "<b>Foreground and Background Colours</b>"
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 #, fuzzy
 msgid "Built-in schemes:"
 msgstr "Built-in Schemes"
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr ""
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 #, fuzzy
 msgid "<b>Palette</b>"
 msgstr "<b>Title</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Colours"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "Scrollbar is:"
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 #, fuzzy
 msgid "Limit scrollback to:"
 msgstr "Scroll-back:"
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "Scroll on Output"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr "Scroll on Keystroke"
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "Scroll Background"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "lines"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>Scrolling</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Scrolling"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -618,53 +639,53 @@ msgstr ""
 "applications and operating systems that expect different terminal behaviour."
 "</i></small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr "_Backspace key generates:"
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr "_Delete key generates:"
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Reset Compatibility Options to Defaults"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>Compatibility</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Compatibility"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "Key bindings"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "Key bindings"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -686,61 +707,53 @@ msgstr ""
 msgid "Unable to run command: `%s'\n"
 msgstr "Unable to run command: `%s'\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr "Unable to open lock directory: %s\n"
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "Use Anti-aliased Fonts"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Set the background colour"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Run a command at startup"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Set the font to the following string"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Show Configuration Wizard"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "Scroll-back Lines"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "Use Scrollbar"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Print the version, then exit"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "Set Initial Working Directory"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Set Background Image"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "Opaqueness: 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "Show Configuration Wizard"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -753,7 +766,7 @@ msgstr ""
 "\n"
 "Error message: %s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, fuzzy, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -767,70 +780,87 @@ msgstr ""
 "\n"
 "Error message: %s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 #, fuzzy
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
 msgstr "The key binding you chose is invalid. Please choose another."
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+msgid "Action"
+msgstr ""
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, fuzzy, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr "The key binding you chose is invalid. Please choose another."
+
+#: src/tilda_terminal.c:397
 #, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr ""
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "Untitled"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr "Bad value for \"d_set_title\" in config file\n"
 
@@ -842,16 +872,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr "You have a bad tab_pos in your configuration file\n"
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "Unable to set tilda's icon: %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "Out of memory, cannot create tab\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -871,22 +901,37 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, fuzzy, c-format
 msgid "Tilda %d Config"
 msgstr "Tilda Config"
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr "Invalid tab position setting, ignoring\n"
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "Enable Anti-aliasing"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Use Image for Background"
+
+#~ msgid "Scroll Background"
+#~ msgstr "Scroll Background"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "Use Anti-aliased Fonts"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Set Background Image"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Enable Double Buffering"
@@ -901,10 +946,6 @@ msgstr "Invalid tab position setting, ignoring\n"
 #, fuzzy
 #~ msgid "<b>Quit</b>"
 #~ msgstr "<b>Title</b>"
-
-#, fuzzy
-#~ msgid "<b>Close Tab</b>"
-#~ msgstr "<b>Command</b>"
 
 #, fuzzy
 #~ msgid "<b>Copy</b>"
@@ -961,11 +1002,6 @@ msgstr "Invalid tab position setting, ignoring\n"
 #, fuzzy
 #~ msgid ""
 #~ "The keybinding you chose for \"Copy\" is invalid. Please choose another."
-#~ msgstr "The key binding you chose is invalid. Please choose another."
-
-#, fuzzy
-#~ msgid ""
-#~ "The keybinding you chose for \"Paste\" is invalid. Please choose another."
 #~ msgstr "The key binding you chose is invalid. Please choose another."
 
 #, fuzzy

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2014-09-07 12:19+0200\n"
 "Last-Translator: micrococo <micrococo@gmx.com>\n"
 "Language-Team: Spanish <kde-i18n-doc@kde.org>\n"
@@ -19,6 +19,39 @@ msgstr ""
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Lokalize 1.5\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr "_Nueva pestaña"
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr "_Cerrar pestaña"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+#, fuzzy
+msgid "_Toggle Fullscreen"
+msgstr "<b>Alternar pantalla completa</b>"
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 msgid "Close Tilda"
@@ -32,19 +65,19 @@ msgstr "Abrir una nueva terminal"
 msgid "Open a new terminal and hide"
 msgstr "Abrir una nueva terminal y ocultarla"
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr "Arriba"
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr "Abajo"
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr "Izquierda"
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr "Derecha"
 
@@ -74,106 +107,106 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
-msgstr "No mostrarlo"
-
-#: src/tilda.ui:143
-msgid "Goes after initial title"
-msgstr "Ponerlo detrás el título inicial"
-
-#: src/tilda.ui:146
-msgid "Goes before initial title"
-msgstr "Ponerlo delante del título inicial"
-
-#: src/tilda.ui:149
-msgid "Replace initial title"
-msgstr "Sustituir el título Inicial"
-
-#: src/tilda.ui:160
-msgid "Drop to the default shell"
-msgstr "Usar la acción predeterminada de la terminal"
-
-#: src/tilda.ui:163
-msgid "Restart the command"
-msgstr "Reiniciar el comando"
-
-#: src/tilda.ui:166
-msgid "Exit the terminal"
-msgstr "Salir de la terminal"
-
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
-msgid "Custom"
-msgstr "Personalizado"
-
-#: src/tilda.ui:200
-msgid "Green on Black"
-msgstr "Verde sobre negro"
-
-#: src/tilda.ui:203
-msgid "Black on White"
-msgstr "Negro sobre blanco"
-
-#: src/tilda.ui:206
-msgid "White on Black"
-msgstr "Blanco sobre negro"
-
-#: src/tilda.ui:209 src/wizard.c:223
-msgid "Zenburn"
-msgstr ""
-
-#: src/tilda.ui:212 src/wizard.c:224
-msgid "Solarized Light"
-msgstr "Solarizado claro"
-
-#: src/tilda.ui:215 src/wizard.c:225
-msgid "Solarized Dark"
-msgstr "Solarizado oscuro"
-
-#: src/tilda.ui:218 src/wizard.c:226
-msgid "Snazzy"
-msgstr ""
-
-#: src/tilda.ui:240
-msgid "On the Left"
-msgstr "A la izquierda"
-
-#: src/tilda.ui:243
-msgid "On the Right"
-msgstr "A la derecha"
-
-#: src/tilda.ui:246
-msgid "Disabled"
-msgstr "Inhabilitada"
-
-#: src/tilda.ui:257 src/tilda.ui:274
-msgid "ASCII DEL"
-msgstr ""
-
-#: src/tilda.ui:260 src/tilda.ui:277
-msgid "Escape sequence"
-msgstr "Secuencia de escape"
-
-#: src/tilda.ui:263 src/tilda.ui:280
-msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
 msgid "Show whole tab title"
 msgstr ""
 
-#: src/tilda.ui:294
+#: src/tilda.ui:143
 msgid "Show first n chars of title"
 msgstr ""
 
-#: src/tilda.ui:297
+#: src/tilda.ui:146
 msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr "No mostrarlo"
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr "Ponerlo detrás el título inicial"
+
+#: src/tilda.ui:163
+msgid "Goes before initial title"
+msgstr "Ponerlo delante del título inicial"
+
+#: src/tilda.ui:166
+msgid "Replace initial title"
+msgstr "Sustituir el título Inicial"
+
+#: src/tilda.ui:177
+msgid "Drop to the default shell"
+msgstr "Usar la acción predeterminada de la terminal"
+
+#: src/tilda.ui:180
+msgid "Restart the command"
+msgstr "Reiniciar el comando"
+
+#: src/tilda.ui:183
+msgid "Exit the terminal"
+msgstr "Salir de la terminal"
+
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
+msgid "Custom"
+msgstr "Personalizado"
+
+#: src/tilda.ui:217
+msgid "Green on Black"
+msgstr "Verde sobre negro"
+
+#: src/tilda.ui:220
+msgid "Black on White"
+msgstr "Negro sobre blanco"
+
+#: src/tilda.ui:223
+msgid "White on Black"
+msgstr "Blanco sobre negro"
+
+#: src/tilda.ui:226 src/wizard.c:223
+msgid "Zenburn"
+msgstr ""
+
+#: src/tilda.ui:229 src/wizard.c:224
+msgid "Solarized Light"
+msgstr "Solarizado claro"
+
+#: src/tilda.ui:232 src/wizard.c:225
+msgid "Solarized Dark"
+msgstr "Solarizado oscuro"
+
+#: src/tilda.ui:235 src/wizard.c:226
+msgid "Snazzy"
+msgstr ""
+
+#: src/tilda.ui:257
+msgid "On the Left"
+msgstr "A la izquierda"
+
+#: src/tilda.ui:260
+msgid "On the Right"
+msgstr "A la derecha"
+
+#: src/tilda.ui:263
+msgid "Disabled"
+msgstr "Inhabilitada"
+
+#: src/tilda.ui:274 src/tilda.ui:291
+msgid "ASCII DEL"
+msgstr ""
+
+#: src/tilda.ui:277 src/tilda.ui:294
+msgid "Escape sequence"
+msgstr "Secuencia de escape"
+
+#: src/tilda.ui:280 src/tilda.ui:297
+msgid "Control-H"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr "Configuración de Tilda"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Iniciar Tilda oculta"
 
@@ -206,72 +239,68 @@ msgstr "Alternar pantalla completa"
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>Visualización de la ventana</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr "Cursor intermitente"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr "Timbre del sistema audible"
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Visualización de la terminal</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "Activar el suavizado de líneas"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "Permitir texto en negrita"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "Tipo de letra:"
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Fuente</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr "Ocultar Tilda cuando el ratón salga de su ventana"
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr "Retardo de la ocultación automática"
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr "Ocultar Tilda cuando pierda el foco"
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Ocultar automáticamente</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr "Al cerrar la última terminal:"
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Siempre visible"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 msgid "<b>Program Exit</b>"
 msgstr "<b>Salir del programa</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
@@ -279,67 +308,67 @@ msgstr ""
 "<small><i><b>Nota:</b> Algunas opciones requieren que se reinicie Tilda.</"
 "i></small>"
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "General"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr "Caracteres de palabra:"
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr "<b>Selección de palabras</b>"
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 msgid "Web Browser *:"
 msgstr "Navegador web *:"
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr "<b>Manejo de las URL</b>"
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Título inicial:"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Establecer título dinámicamente:"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Título</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr "Ejecutar un comando personalizado en lugar de la terminal"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "Comando personalizado:"
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr "Cuando el comando termine:"
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Comando</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -351,134 +380,130 @@ msgstr ""
 "'google-chrome' o los comandos genéricos 'x-www-browser' y 'xdg-open'. El "
 "comando más apropiado puede ser distinto dependiendo del sistema."
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 #, fuzzy
 msgid "Close Action"
 msgstr "Cerrar Tilda"
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Título y comando"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Porcentaje"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "Píxeles"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Alto</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr "Monitor:"
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 msgid "<b>Select monitor</b>"
 msgstr "<b>Selección del monitor</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Ancho</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Centrado horizontalmente"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Posición Y"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "Posición X"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Centrado verticalmente"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Posición</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr "Posición de las pestañas:"
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Añadir pestaña</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Retardo de la animación (µseg)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Sentido de la animación"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Usar imagen de fondo"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Animar la aparición de la ventana"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Nivel de transparencia"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Activar transparencia"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Extras</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Apariencia"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 #, fuzzy
 msgid "Cursor Color"
 msgstr "Cursor intermitente"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "Color del texto"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "Color de fondo"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr "Esquemas internos"
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr "<b>Color del texto y del fondo</b>"
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
@@ -486,128 +511,124 @@ msgstr ""
 "<small><i><b>Nota:</b> Las aplicaciones de terminal tienen estos colores a "
 "su disposición.</i></small>"
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 msgid "Built-in schemes:"
 msgstr "Esquemas internos:"
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr "Paleta de color:"
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Colores"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "Barra de desplazamiento:"
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 #, fuzzy
 msgid "Limit scrollback to:"
 msgstr "Desplazamiento hacia atrás"
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "Desplazar tras salida"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr "Desplazar al teclear"
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "Desplazar el fondo"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "líneas"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>Desplazamiento</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Desplazamiento"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -619,53 +640,53 @@ msgstr ""
 "ciertas aplicaciones y sistemas operativos que esperan un comportamiento "
 "diferente del terminal.</i></small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr "La tecla _Retroceso produce:"
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr "La tecla _Suprimir produce:"
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Reiniciar las opciones de compatibilidad a las predeterminadas"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>Compatibilidad</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Compatibilidad"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "Atajos de teclado"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "Atajos de teclado"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -687,61 +708,53 @@ msgstr "No se puede escribir el fichero de configuración en %s\n"
 msgid "Unable to run command: `%s'\n"
 msgstr "No se puede ejecutar el comando: `%s'\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr "No se puede abrir el directorio bloqueado %s\n"
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "Usar suavizado de fuentes"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Establecer el color de fondo"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Ejecutar un comando al inicio"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Establecer la fuente con la cadena siguiente"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Mostrar el asistente de configuración"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "Desplazar líneas hacia atrás"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "Usar barra de desplazamiento"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Imprimir la version y luego salir"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "Elegir el directorio de trabajo inicial"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Elegir la imagen de fondo"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "Opacidad: 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "Mostrar el asistente de configuración"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -755,7 +768,7 @@ msgstr ""
 "\n"
 "Mensaje de error: %s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, fuzzy, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -770,32 +783,32 @@ msgstr ""
 "\n"
 "Mensaje de error: %s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr "Crear directorio:'%s'\n"
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 "Encontrado style.css en el directorio de configuración del usuario, "
 "aplicando el estilo css del usuario.\n"
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr "Migrando la antigua ruta de configuración a directorios XDG\n"
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
@@ -803,40 +816,60 @@ msgstr ""
 "El atajo de teclado que ha elegido para \"Mostrar la terminal\" es inválido. "
 "Seleccione otro, por favor."
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+#, fuzzy
+msgid "Action"
+msgstr "Cerrar Tilda"
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr "Introduzca el atajo de teclado"
+
+#: src/tilda-keybinding.c:417
+#, fuzzy, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+"El atajo de teclado que ha elegido para \"Pegar\" es inválido. Seleccione "
+"otro, por favor."
+
+#: src/tilda_terminal.c:397
 #, fuzzy, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr "Problema procesando el comando personalizado: %s\n"
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr "Problema procesando el comando personalizado: %s\n"
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr "Ejecutando la terminal predeterminada en su lugar\n"
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr "No se puede ejecutar el comando personalizado %s\n"
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr "No se puede ejecutar la terminal predeterminada: %s\n"
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr "Fallo al ejecutar el navegador web. El comando era '%s'\n"
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "Sin título"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr "Valor erróneo para \"d_set_title\" en el fichero de configuración\n"
 
@@ -848,16 +881,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr "Tiene un tab_pos erróneo en su archivo de configuración\n"
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "No se puede establecer el icono de Tilda: %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "No hay memoria disponible, no se puede crear la pestaña\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -877,22 +910,37 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, c-format
 msgid "Tilda %d Config"
 msgstr "Configuración %d de Tilda"
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr "Posición no válida para la pestaña, se ignora\n"
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "Activar el suavizado de líneas"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Usar imagen de fondo"
+
+#~ msgid "Scroll Background"
+#~ msgstr "Desplazar el fondo"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "Usar suavizado de fuentes"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Elegir la imagen de fondo"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Habilitar memoria temporal doble"
@@ -963,21 +1011,12 @@ msgstr "Posición no válida para la pestaña, se ignora\n"
 #~ msgid "<b>Move Tab Right</b>"
 #~ msgstr "<b>Mover pestaña a la derecha</b>"
 
-#~ msgid "<b>Toggle Fullscreen</b>"
-#~ msgstr "<b>Alternar pantalla completa</b>"
-
 #~ msgid "Problem when opening config file\n"
 #~ msgstr "Problema al abrir el fichero de configuración\n"
 
 #~ msgid "An unexpected error occured while parsing the config file\n"
 #~ msgstr ""
 #~ "Ha ocurrido un error inesperado al procesar el archivo de configuración\n"
-
-#~ msgid "_New Tab"
-#~ msgstr "_Nueva pestaña"
-
-#~ msgid "_Close Tab"
-#~ msgstr "_Cerrar pestaña"
 
 #~ msgid ""
 #~ "The keybinding you chose for \"Add Tab\" is invalid. Please choose "
@@ -1026,12 +1065,6 @@ msgstr "Posición no válida para la pestaña, se ignora\n"
 #~ msgstr ""
 #~ "El atajo de teclado que ha elegido para \"Copiar\" es inválido. "
 #~ "Seleccione otro, por favor."
-
-#~ msgid ""
-#~ "The keybinding you chose for \"Paste\" is invalid. Please choose another."
-#~ msgstr ""
-#~ "El atajo de teclado que ha elegido para \"Pegar\" es inválido. Seleccione "
-#~ "otro, por favor."
 
 #~ msgid ""
 #~ "The keybinding you chose for \"Quit\" is invalid. Please choose another."
@@ -1115,9 +1148,6 @@ msgstr "Posición no válida para la pestaña, se ignora\n"
 #~ msgstr ""
 #~ "El atajo de teclado que ha elegido para \"Alternar pantalla completa\" es "
 #~ "inválido. Seleccione otro, por favor."
-
-#~ msgid "Enter keyboard shortcut"
-#~ msgstr "Introduzca el atajo de teclado"
 
 #~ msgid "Problem while parsing config file\n"
 #~ msgstr "Problema al procesar el fichero de configuración\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2008-03-10 22:11+0000\n"
 "Last-Translator: François Boulogne <Unknown>\n"
 "Language-Team: French <fr@li.org>\n"
@@ -17,6 +17,39 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr "_Nouvel onglet"
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr "_Fermer l'onglet"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+#, fuzzy
+msgid "_Toggle Fullscreen"
+msgstr "Passer en mode plein écran"
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 #, fuzzy
@@ -31,19 +64,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -72,83 +105,95 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
+msgid "Show whole tab title"
 msgstr ""
 
 #: src/tilda.ui:143
-msgid "Goes after initial title"
+msgid "Show first n chars of title"
 msgstr ""
 
 #: src/tilda.ui:146
+msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
 msgid "Goes before initial title"
 msgstr ""
 
-#: src/tilda.ui:149
+#: src/tilda.ui:166
 #, fuzzy
 msgid "Replace initial title"
 msgstr "Titre initial :"
 
-#: src/tilda.ui:160
+#: src/tilda.ui:177
 msgid "Drop to the default shell"
 msgstr ""
 
-#: src/tilda.ui:163
+#: src/tilda.ui:180
 msgid "Restart the command"
 msgstr ""
 
-#: src/tilda.ui:166
+#: src/tilda.ui:183
 msgid "Exit the terminal"
 msgstr ""
 
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
 msgid "Custom"
 msgstr "Personnalisé"
 
-#: src/tilda.ui:200
+#: src/tilda.ui:217
 msgid "Green on Black"
 msgstr ""
 
-#: src/tilda.ui:203
+#: src/tilda.ui:220
 msgid "Black on White"
 msgstr ""
 
-#: src/tilda.ui:206
+#: src/tilda.ui:223
 msgid "White on Black"
 msgstr ""
 
-#: src/tilda.ui:209 src/wizard.c:223
+#: src/tilda.ui:226 src/wizard.c:223
 msgid "Zenburn"
 msgstr ""
 
-#: src/tilda.ui:212 src/wizard.c:224
+#: src/tilda.ui:229 src/wizard.c:224
 msgid "Solarized Light"
 msgstr ""
 
-#: src/tilda.ui:215 src/wizard.c:225
+#: src/tilda.ui:232 src/wizard.c:225
 msgid "Solarized Dark"
 msgstr ""
 
-#: src/tilda.ui:218 src/wizard.c:226
+#: src/tilda.ui:235 src/wizard.c:226
 msgid "Snazzy"
 msgstr ""
 
-#: src/tilda.ui:240
+#: src/tilda.ui:257
 msgid "On the Left"
 msgstr ""
 
-#: src/tilda.ui:243
+#: src/tilda.ui:260
 msgid "On the Right"
 msgstr ""
 
-#: src/tilda.ui:246
+#: src/tilda.ui:263
 msgid "Disabled"
 msgstr ""
 
-#: src/tilda.ui:257 src/tilda.ui:274
+#: src/tilda.ui:274 src/tilda.ui:291
 msgid "ASCII DEL"
 msgstr ""
 
-#: src/tilda.ui:260 src/tilda.ui:277
+#: src/tilda.ui:277 src/tilda.ui:294
 #, fuzzy
 msgid "Escape sequence"
 msgstr ""
@@ -156,27 +201,15 @@ msgstr ""
 "Séquence d'échappement\n"
 "Ctrl-H"
 
-#: src/tilda.ui:263 src/tilda.ui:280
+#: src/tilda.ui:280 src/tilda.ui:297
 msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
-msgid "Show whole tab title"
-msgstr ""
-
-#: src/tilda.ui:294
-msgid "Show first n chars of title"
-msgstr ""
-
-#: src/tilda.ui:297
-msgid "Show last n chars of title"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr "Configuration de Tilda"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Démarrer Tilda caché"
 
@@ -209,141 +242,137 @@ msgstr "Passer en mode plein écran"
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>Affichage de la fenêtre</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 #, fuzzy
 msgid "Cursor Blinks"
 msgstr "Curseur clignotant"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr ""
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Affichage du terminal</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "Activer l'Antialiasing"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "Autoriser le texte en gras"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "Police :"
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Police de caractères</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr "Masquer Tilda lorsque le pointeur le quitte"
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr "Délais de masquage automatique"
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr "Masquer lorsque Tilda perd le focus"
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Masquage automatique</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Toujours en avant plan"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 #, fuzzy
 msgid "<b>Program Exit</b>"
 msgstr "<b>Position</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "Généralités"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr ""
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr "<b>Sélectionner par mots</b>"
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 #, fuzzy
 msgid "Web Browser *:"
 msgstr "Navigateur Web"
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr "<b>Traitement des URL</b>"
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Titre initial :"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Titre paramétré dynamiquement :"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Titre</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr "Exécuter une commande personnalisée au lieu du terminal"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "Commande personnalisée :"
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr "Lorsque la commande se termine :"
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Commande</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -351,263 +380,255 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 #, fuzzy
 msgid "Close Action"
 msgstr "_Fermer l'onglet"
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Titre et commande"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Pourcentage"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "En pixels"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Hauteur</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 #, fuzzy
 msgid "<b>Select monitor</b>"
 msgstr "<b>Sélectionner par mots</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Largeur</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Centré horizontalement"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Position Y"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "Position X"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Centré verticalement"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Position</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr "Position des onglets :"
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Ajouter un onglet</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Durée de l'animation (µsec)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Orientation de l'animation"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Utiliser une image d'arrière-plan"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Arrivée animée"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Degré de transparence"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Activer la transparence"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Compléments</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Apparence"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 #, fuzzy
 msgid "Cursor Color"
 msgstr "Curseur clignotant"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "Couleur du texte"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "Couleur d'arrière-plan"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr ""
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 #, fuzzy
 msgid "<b>Foreground and Background Colors</b>"
 msgstr "<b>Couleurs de premier et d'arrière plan</b>"
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 msgid "Built-in schemes:"
 msgstr ""
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr "Palette de couleurs :"
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 msgid "<b>Palette</b>"
 msgstr "<b>Palette</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Couleurs"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "La barre de défilement est :"
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 #, fuzzy
 msgid "Limit scrollback to:"
 msgstr "Capacité de défilement  :"
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "Faire défiler sur la sortie standard"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr ""
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "Faire défiler l'arrière-plan"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "lignes"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>Défilement</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Défilement"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -619,53 +640,53 @@ msgstr ""
 "fonctionner certaines applications et systèmes d'exploitation qui attendent "
 "un comportement du terminal différent.</i></small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr "La touche « _Retour arrière » émet :"
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr "La touche « _Suppr » émet :"
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Réinitialiser les options de compatibilité aux valeurs par défaut"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>Compatibilité</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Compatibilité"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "Raccourcis clavier"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "Raccourcis clavier"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -687,61 +708,53 @@ msgstr "Ne peut pas écrire le fichier de configuration dans %s\n"
 msgid "Unable to run command: `%s'\n"
 msgstr "Impossible d'exécuter la commande : '%s'\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr ""
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "Utiliser des polices antialiasées"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Paramètrer la couleur de fond"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Lancer une commande au démarrage"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Paramètrer la police à la chaine de caractères suivante"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Montrer l'outil de configuration"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "Lignes d'historique"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "Utiliser la barre de défilement"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Renvoyer la version, puis quitter"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "Paramètrer le dossier de travail initial"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Paramètrer l'image de fond"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "Opacité : 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "Montrer l'outil de configuration"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -754,7 +767,7 @@ msgstr ""
 "\n"
 "Message d'erreur : %s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, fuzzy, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -768,30 +781,30 @@ msgstr ""
 "\n"
 "Message d'erreur : %s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 #, fuzzy
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
@@ -800,40 +813,60 @@ msgstr ""
 "Le raccourcis clavier que vous avez choisi est invalide. S'il-vous-plaît, "
 "choisissez en un autre."
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+#, fuzzy
+msgid "Action"
+msgstr "_Fermer l'onglet"
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, fuzzy, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+"Le raccourcis clavier que vous avez choisi est invalide. S'il-vous-plaît, "
+"choisissez en un autre."
+
+#: src/tilda_terminal.c:397
 #, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr ""
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr "Impossible de lancer la commande personnalisée : %s\n"
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr "Echec du lancement du navigateur web. La commande était `%s'\n"
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "Sans nom"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr ""
 "Mauvaise valeur pour \"d_set_title\" dans le fichier de configuration\n"
@@ -848,16 +881,16 @@ msgstr ""
 "Vous avez un mauvais positionnement des onglets dans votre fichier de "
 "configuration\n"
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "Ne peut pas paramétrer l'icône de tilda : %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "Plus de mémoire, ne peut pas créer l'onglet\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -877,22 +910,37 @@ msgstr "Xterm"
 msgid "Rxvt"
 msgstr "Rxvt"
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, c-format
 msgid "Tilda %d Config"
 msgstr ""
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr ""
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "Activer l'Antialiasing"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Utiliser une image d'arrière-plan"
+
+#~ msgid "Scroll Background"
+#~ msgstr "Faire défiler l'arrière-plan"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "Utiliser des polices antialiasées"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Paramètrer l'image de fond"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Activer le Double Buffering"
@@ -961,18 +1009,8 @@ msgstr ""
 #~ msgstr "<b>Hauteur</b>"
 
 #, fuzzy
-#~ msgid "<b>Toggle Fullscreen</b>"
-#~ msgstr "Passer en mode plein écran"
-
-#, fuzzy
 #~ msgid "Problem when opening config file\n"
 #~ msgstr "Problème lors de l'analyse du fichier de configuration\n"
-
-#~ msgid "_New Tab"
-#~ msgstr "_Nouvel onglet"
-
-#~ msgid "_Close Tab"
-#~ msgstr "_Fermer l'onglet"
 
 #, fuzzy
 #~ msgid ""
@@ -1025,13 +1063,6 @@ msgstr ""
 #, fuzzy
 #~ msgid ""
 #~ "The keybinding you chose for \"Copy\" is invalid. Please choose another."
-#~ msgstr ""
-#~ "Le raccourcis clavier que vous avez choisi est invalide. S'il-vous-plaît, "
-#~ "choisissez en un autre."
-
-#, fuzzy
-#~ msgid ""
-#~ "The keybinding you chose for \"Paste\" is invalid. Please choose another."
 #~ msgstr ""
 #~ "Le raccourcis clavier que vous avez choisi est invalide. S'il-vous-plaît, "
 #~ "choisissez en un autre."

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2008-03-05 00:28+0000\n"
 "Last-Translator: Pittmann Tamás <zaivaldi@gmail.com>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -17,6 +17,38 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr "Új _fül"
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr "Fül _bezárása"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 #, fuzzy
@@ -31,19 +63,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -73,84 +105,96 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
+msgid "Show whole tab title"
 msgstr ""
 
 #: src/tilda.ui:143
-msgid "Goes after initial title"
+msgid "Show first n chars of title"
 msgstr ""
 
 #: src/tilda.ui:146
+msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
 msgid "Goes before initial title"
 msgstr ""
 
-#: src/tilda.ui:149
+#: src/tilda.ui:166
 #, fuzzy
 msgid "Replace initial title"
 msgstr "Ablakcím induláskor:"
 
-#: src/tilda.ui:160
+#: src/tilda.ui:177
 #, fuzzy
 msgid "Drop to the default shell"
 msgstr "Nem tudom elindítani az alapértelmezett héjat: %s\n"
 
-#: src/tilda.ui:163
+#: src/tilda.ui:180
 msgid "Restart the command"
 msgstr ""
 
-#: src/tilda.ui:166
+#: src/tilda.ui:183
 msgid "Exit the terminal"
 msgstr ""
 
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
 msgid "Custom"
 msgstr ""
 
-#: src/tilda.ui:200
+#: src/tilda.ui:217
 msgid "Green on Black"
 msgstr ""
 
-#: src/tilda.ui:203
+#: src/tilda.ui:220
 msgid "Black on White"
 msgstr ""
 
-#: src/tilda.ui:206
+#: src/tilda.ui:223
 msgid "White on Black"
 msgstr ""
 
-#: src/tilda.ui:209 src/wizard.c:223
+#: src/tilda.ui:226 src/wizard.c:223
 msgid "Zenburn"
 msgstr ""
 
-#: src/tilda.ui:212 src/wizard.c:224
+#: src/tilda.ui:229 src/wizard.c:224
 msgid "Solarized Light"
 msgstr ""
 
-#: src/tilda.ui:215 src/wizard.c:225
+#: src/tilda.ui:232 src/wizard.c:225
 msgid "Solarized Dark"
 msgstr ""
 
-#: src/tilda.ui:218 src/wizard.c:226
+#: src/tilda.ui:235 src/wizard.c:226
 msgid "Snazzy"
 msgstr ""
 
-#: src/tilda.ui:240
+#: src/tilda.ui:257
 msgid "On the Left"
 msgstr ""
 
-#: src/tilda.ui:243
+#: src/tilda.ui:260
 msgid "On the Right"
 msgstr ""
 
-#: src/tilda.ui:246
+#: src/tilda.ui:263
 msgid "Disabled"
 msgstr ""
 
-#: src/tilda.ui:257 src/tilda.ui:274
+#: src/tilda.ui:274 src/tilda.ui:291
 msgid "ASCII DEL"
 msgstr ""
 
-#: src/tilda.ui:260 src/tilda.ui:277
+#: src/tilda.ui:277 src/tilda.ui:294
 #, fuzzy
 msgid "Escape sequence"
 msgstr ""
@@ -158,27 +202,15 @@ msgstr ""
 "Escape sorozat\n"
 "Control-H"
 
-#: src/tilda.ui:263 src/tilda.ui:280
+#: src/tilda.ui:280 src/tilda.ui:297
 msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
-msgid "Show whole tab title"
-msgstr ""
-
-#: src/tilda.ui:294
-msgid "Show first n chars of title"
-msgstr ""
-
-#: src/tilda.ui:297
-msgid "Show last n chars of title"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr "Tilda Beállítás"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Tilda indítása rejtve"
 
@@ -210,141 +242,137 @@ msgstr ""
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>Ablak beállítások</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr "Villogó kurzor"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr "Hangos terminál csengő"
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Terminál beállítások</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "Élsimítás bekapcsolása"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "Félkövér szöveg engedélyezése"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "Betűkészlet:"
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Betűkészlet</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr ""
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr ""
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr ""
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 #, fuzzy
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Cím</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Mindig felül"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 #, fuzzy
 msgid "<b>Program Exit</b>"
 msgstr "<b>Elhelyezés</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "Általános"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr ""
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr ""
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 #, fuzzy
 msgid "Web Browser *:"
 msgstr "Webböngésző"
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr "<b>URL kezelés</b>"
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Ablakcím induláskor:"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Dinamikus ablakcím:"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Cím</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr "Héj helyett saját parancs futtatása"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "Saját parancs:"
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr "Parancs befejeződésekor:"
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Parancs</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -352,264 +380,256 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 #, fuzzy
 msgid "Close Action"
 msgstr "Fül _bezárása"
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Cím és parancs"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Százalék"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "Képpont"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Magasság</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 #, fuzzy
 msgid "<b>Select monitor</b>"
 msgstr "<b>Cím</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Szélesség</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Vizszintesen középre"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Y pozíció"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "X pozíció"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Függőlegesen középre"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Elhelyezés</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr "Fülek helye"
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Cím</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Animáció késleltetése (usec)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Animáció iránya"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Kép használata háttérként"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Animált lenyitás"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Átlátszóság szintje:"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Átlátszóság engedélyezése"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Extrák</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Megjelenés"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 #, fuzzy
 msgid "Cursor Color"
 msgstr "Villogó kurzor"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "Szövegszín"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "Háttérszín"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr "Beépített színsémák"
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr "<b>Előtér és háttérszínek</b>"
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 #, fuzzy
 msgid "Built-in schemes:"
 msgstr "Beépített színsémák"
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr ""
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 #, fuzzy
 msgid "<b>Palette</b>"
 msgstr "<b>Cím</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Színek"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "Görgetősáv helye:"
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 #, fuzzy
 msgid "Limit scrollback to:"
 msgstr "Visszagörgethető sorok száma"
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "Görgetés kiíráskor"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr "Görgetés billentyű leütésre"
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "Háttér görgetése"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "sor"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>Görgetés</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Görgetés"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -622,53 +642,53 @@ msgstr ""
 "együttműködését, amelyek más igényeket támasztanak a terminállal szemben.</"
 "i></small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr "A _Backspace billentyű által küldött kód:"
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr "A _Delete billentyű által küldött kód:"
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Kompatibilitási beállítások alapértelmezettre állítása"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>Kompatibilitás</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Kompatibilitás"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "Gyorsbillentyű"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "Gyorsbillentyű"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -690,61 +710,53 @@ msgstr "Nem tudom írni a konfigfájlt: %s\n"
 msgid "Unable to run command: `%s'\n"
 msgstr "A '%s' parancs futtatása nem sikerült\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr "Nem tudom megnyitni a zárolási könyvtárat :%s\n"
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "Élsimított betűkészletek használata"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Háttérszín beállítása"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Parancs futtatása induláskor"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Betűkészlet beállítása erre a karakterláncra"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Indítás konfigurációs ablakkal"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "Visszagördíthető sorok száma"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "Görgetősáv használata"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Verzió kiírása és kilépés"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "Kezdő munkakönyvtár beállítása"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Háttérkép beállítása"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "Átlátszóság: 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "Indítás konfigurációs ablakkal"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -756,7 +768,7 @@ msgstr ""
 "\n"
 "Hiba: %s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, fuzzy, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -769,70 +781,88 @@ msgstr ""
 "\n"
 "Hiba: %s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 #, fuzzy
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
 msgstr "A választott gyorsbillentyű érvénytelen. Válasszon másikat."
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+#, fuzzy
+msgid "Action"
+msgstr "Fül _bezárása"
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, fuzzy, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr "A választott gyorsbillentyű érvénytelen. Válasszon másikat."
+
+#: src/tilda_terminal.c:397
 #, fuzzy, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr "Parancs értelmezési hiba: %s\n"
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr "Parancs értelmezési hiba: %s\n"
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr "Helyette indítom az alapértelmezett héjat.\n"
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr "Nem tudom elindítani a megadott felhasználói parancsot: %s\n"
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr "Nem tudom elindítani az alapértelmezett héjat: %s\n"
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr "Nem tudtam elindítani a böngészőt, parancs: %s\n"
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "Névtelen"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr "Hibás érték a konfigfájlban itt: \"d_set_title\"\n"
 
@@ -844,16 +874,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr "A konfigfájlban hibás a fülek pozíciója\n"
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "Nem tudom a tilda ikonját beállítani: %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "Elfogyott a memória. a fül nem hozható létre\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -873,22 +903,37 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, fuzzy, c-format
 msgid "Tilda %d Config"
 msgstr "Tilda Beállítás"
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr "Érvénytelen fülpozíció, figyelmen kívül lesz hagyva\n"
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "Élsimítás bekapcsolása"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Kép használata háttérként"
+
+#~ msgid "Scroll Background"
+#~ msgstr "Háttér görgetése"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "Élsimított betűkészletek használata"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Háttérkép beállítása"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Dupla gyorstár engedélyezése"
@@ -927,12 +972,6 @@ msgstr "Érvénytelen fülpozíció, figyelmen kívül lesz hagyva\n"
 #, fuzzy
 #~ msgid "Problem when opening config file\n"
 #~ msgstr "Hiba a konfigfájlban.\n"
-
-#~ msgid "_New Tab"
-#~ msgstr "Új _fül"
-
-#~ msgid "_Close Tab"
-#~ msgstr "Fül _bezárása"
 
 #, fuzzy
 #~ msgid ""
@@ -973,11 +1012,6 @@ msgstr "Érvénytelen fülpozíció, figyelmen kívül lesz hagyva\n"
 #, fuzzy
 #~ msgid ""
 #~ "The keybinding you chose for \"Copy\" is invalid. Please choose another."
-#~ msgstr "A választott gyorsbillentyű érvénytelen. Válasszon másikat."
-
-#, fuzzy
-#~ msgid ""
-#~ "The keybinding you chose for \"Paste\" is invalid. Please choose another."
 #~ msgstr "A választott gyorsbillentyű érvénytelen. Válasszon másikat."
 
 #, fuzzy

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2010-08-22 18:58+0000\n"
 "Last-Translator: Davide Truffa <davide@catoblepa.org>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -17,6 +17,39 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2010-08-23 16:08+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr "_Nuova scheda"
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr "_Chiudi scheda"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+#, fuzzy
+msgid "_Toggle Fullscreen"
+msgstr "Schermo Intero"
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 #, fuzzy
@@ -31,19 +64,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -73,84 +106,96 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
+msgid "Show whole tab title"
 msgstr ""
 
 #: src/tilda.ui:143
-msgid "Goes after initial title"
+msgid "Show first n chars of title"
 msgstr ""
 
 #: src/tilda.ui:146
+msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
 msgid "Goes before initial title"
 msgstr ""
 
-#: src/tilda.ui:149
+#: src/tilda.ui:166
 #, fuzzy
 msgid "Replace initial title"
 msgstr "Titolo iniziale:"
 
-#: src/tilda.ui:160
+#: src/tilda.ui:177
 #, fuzzy
 msgid "Drop to the default shell"
 msgstr "Impossibile eseguire la shell predefinita: %s\n"
 
-#: src/tilda.ui:163
+#: src/tilda.ui:180
 msgid "Restart the command"
 msgstr ""
 
-#: src/tilda.ui:166
+#: src/tilda.ui:183
 msgid "Exit the terminal"
 msgstr ""
 
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
 msgid "Custom"
 msgstr "Personalizzata"
 
-#: src/tilda.ui:200
+#: src/tilda.ui:217
 msgid "Green on Black"
 msgstr ""
 
-#: src/tilda.ui:203
+#: src/tilda.ui:220
 msgid "Black on White"
 msgstr ""
 
-#: src/tilda.ui:206
+#: src/tilda.ui:223
 msgid "White on Black"
 msgstr ""
 
-#: src/tilda.ui:209 src/wizard.c:223
+#: src/tilda.ui:226 src/wizard.c:223
 msgid "Zenburn"
 msgstr ""
 
-#: src/tilda.ui:212 src/wizard.c:224
+#: src/tilda.ui:229 src/wizard.c:224
 msgid "Solarized Light"
 msgstr ""
 
-#: src/tilda.ui:215 src/wizard.c:225
+#: src/tilda.ui:232 src/wizard.c:225
 msgid "Solarized Dark"
 msgstr ""
 
-#: src/tilda.ui:218 src/wizard.c:226
+#: src/tilda.ui:235 src/wizard.c:226
 msgid "Snazzy"
 msgstr ""
 
-#: src/tilda.ui:240
+#: src/tilda.ui:257
 msgid "On the Left"
 msgstr ""
 
-#: src/tilda.ui:243
+#: src/tilda.ui:260
 msgid "On the Right"
 msgstr ""
 
-#: src/tilda.ui:246
+#: src/tilda.ui:263
 msgid "Disabled"
 msgstr ""
 
-#: src/tilda.ui:257 src/tilda.ui:274
+#: src/tilda.ui:274 src/tilda.ui:291
 msgid "ASCII DEL"
 msgstr ""
 
-#: src/tilda.ui:260 src/tilda.ui:277
+#: src/tilda.ui:277 src/tilda.ui:294
 #, fuzzy
 msgid "Escape sequence"
 msgstr ""
@@ -158,27 +203,15 @@ msgstr ""
 "Sequenza di Escape\n"
 "Control-H"
 
-#: src/tilda.ui:263 src/tilda.ui:280
+#: src/tilda.ui:280 src/tilda.ui:297
 msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
-msgid "Show whole tab title"
-msgstr ""
-
-#: src/tilda.ui:294
-msgid "Show first n chars of title"
-msgstr ""
-
-#: src/tilda.ui:297
-msgid "Show last n chars of title"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr "Configurazione di Tilda"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Lancia Tilda nascosta"
 
@@ -211,73 +244,69 @@ msgstr "Schermo Intero"
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>Finestra</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr "Cursore intermittente"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr "Avviso acustico"
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Terminale</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "Abilita Antialiasing"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "Consentire il testo in grassetto"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "Carattere:"
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Carattere</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr "Nascondi tilda all'uscita del mouse"
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr "Ritardo scomparsa automatica:"
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr "Nascondi tilda alla perdita del focus"
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Scomparsa Automatica</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Sempre in primo piano"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 #, fuzzy
 msgid "<b>Program Exit</b>"
 msgstr "<b>Posizione</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 #, fuzzy
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
@@ -286,69 +315,69 @@ msgstr ""
 "<small><i><b>Nota:</b> colori disponibili per le applicazioni da terminale.</"
 "i></small>"
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "Generale"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 #, fuzzy
 msgid "Word Characters:"
 msgstr "Caratteri selezionabili come parola"
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr "<b>Seleziona Parole</b>"
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 #, fuzzy
 msgid "Web Browser *:"
 msgstr "Browser web"
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr "<b>Gestione URL</b>"
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Titolo iniziale:"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Titolo impostato dinamicamente:"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Titolo</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr "Esegui un comando personalizzato al posto della shell"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "Comando Personalizzato:"
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr "Comando personalizzato:"
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Comando</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -356,135 +385,131 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 #, fuzzy
 msgid "Close Action"
 msgstr "_Chiudi scheda"
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Titolo e comando"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Percentuale"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "In pixel"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Altezza</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 #, fuzzy
 msgid "<b>Select monitor</b>"
 msgstr "<b>Seleziona Parole</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Larghezza</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Centra orizzontalmente"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Posizione verticale"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "Posizione orizzontale"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Centra verticalmente"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Posizione</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr "Posizione delle schede:"
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Nuova scheda</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Durata dell'animazione (usec)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Direzione dell'animazione"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Usa un'immagine per lo sfondo"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Comparsa animata"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Livello di trasparenza"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Abilitare la trasparenza"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Extra</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Aspetto"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 #, fuzzy
 msgid "Cursor Color"
 msgstr "Cursore intermittente"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "Colore del testo"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "Colore di sfondo"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr "Schemi incorporati"
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr "<b>Primo piano e sfondo</b>"
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
@@ -492,128 +517,124 @@ msgstr ""
 "<small><i><b>Nota:</b> colori disponibili per le applicazioni da terminale.</"
 "i></small>"
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 msgid "Built-in schemes:"
 msgstr "Schemi incorporati"
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr "Tavolozza dei colori:"
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 msgid "<b>Palette</b>"
 msgstr "<b>Tavolozza</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Colori"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "Barra di scorrimento:"
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 #, fuzzy
 msgid "Limit scrollback to:"
 msgstr "Scorrimento all'indietro:"
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "Scorrere in presenza di output"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr "Scorrere alla pressione dei tasti"
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "Scorrere in background"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "righe"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>Scorrimento</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Scorrimento"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -625,53 +646,53 @@ msgstr ""
 "applicazioni e sistemi operativi che si aspettano un diverso funzionamento "
 "del terminale.</i></small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr "Il tasto «_Backspace» genera:"
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr "Il tasto «_Canc» genera:"
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Ripristina valori predefiniti per opzioni di compatibilità"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>Compatibilità</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Compatibilità"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "Scorciatoie da tastiera"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "Scorciatoie da tastiera"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -693,61 +714,53 @@ msgstr "Impossibile scrivere il file di configurazione in %s\n"
 msgid "Unable to run command: `%s'\n"
 msgstr "Impossibile avviare il comando: `%s'\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr "Impossibile aprire la directory di lock: %s\n"
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "Abilita l'Antialiasing per i caratteri"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Imposta il colore di sfondo"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Esegui un comando all'avvio"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Imposta il carattere alla seguente stringa"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Mostra wizard di configurazione"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "Linee di scorrimento"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "Abilita barra di scorrimento"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Mostra numero di versione ed esce"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "Imposta directory iniziale"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Imposta immagine di sfondo"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "Opacità: 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "Mostra wizard di configurazione"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -760,7 +773,7 @@ msgstr ""
 "\n"
 "Messaggio di errore: %s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, fuzzy, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -774,30 +787,30 @@ msgstr ""
 "\n"
 "Messaggio di errore: %s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
@@ -805,40 +818,60 @@ msgstr ""
 "La scorciatoia da tastiera scelta per \"Comparsa terminale\" non è valida. "
 "Selezionarne un'altra."
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+#, fuzzy
+msgid "Action"
+msgstr "_Chiudi scheda"
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, fuzzy, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+"La scorciatoia da tastiera scelta per \"Incolla\" non è valida. Selezionarne "
+"un'altra."
+
+#: src/tilda_terminal.c:397
 #, fuzzy, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr "Problemi analizzando il comando personalizzato: %s\n"
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr "Problemi analizzando il comando personalizzato: %s\n"
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr "Avvio della shell predefinita\n"
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr "Impossibile avviare il comando personalizzato: %s\n"
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr "Impossibile eseguire la shell predefinita: %s\n"
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr "Impossibile avviare il browser web tramite il comando: `%s'\n"
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "Senza titolo"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr "Valore errato \"d_set_title\" nel file di configurazione\n"
 
@@ -850,16 +883,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr "Valore errato \"tab_pos\" nel file di configurazione\n"
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "Impossibile impostare l'icona di Tilda: %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "Memoria insufficiente, non posso creare la scheda\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -879,22 +912,37 @@ msgstr "XTerm"
 msgid "Rxvt"
 msgstr "Rxvt"
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, c-format
 msgid "Tilda %d Config"
 msgstr "Configurazione di di Tilda - Sessione %d"
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr "Posizionamento delle schede non valido, verrà ignorato\n"
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "Abilita Antialiasing"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Usa un'immagine per lo sfondo"
+
+#~ msgid "Scroll Background"
+#~ msgstr "Scorrere in background"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "Abilita l'Antialiasing per i caratteri"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Imposta immagine di sfondo"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Abilita Double Buffering"
@@ -965,18 +1013,8 @@ msgstr "Posizionamento delle schede non valido, verrà ignorato\n"
 #~ msgstr "<b>Altezza</b>"
 
 #, fuzzy
-#~ msgid "<b>Toggle Fullscreen</b>"
-#~ msgstr "Schermo Intero"
-
-#, fuzzy
 #~ msgid "Problem when opening config file\n"
 #~ msgstr "Problemi analizzando il file di configurazione\n"
-
-#~ msgid "_New Tab"
-#~ msgstr "_Nuova scheda"
-
-#~ msgid "_Close Tab"
-#~ msgstr "_Chiudi scheda"
 
 #~ msgid ""
 #~ "The keybinding you chose for \"Add Tab\" is invalid. Please choose "
@@ -1026,12 +1064,6 @@ msgstr "Posizionamento delle schede non valido, verrà ignorato\n"
 #~ "The keybinding you chose for \"Copy\" is invalid. Please choose another."
 #~ msgstr ""
 #~ "La scorciatoia da tastiera scelta per \"Copia\" non è valida. "
-#~ "Selezionarne un'altra."
-
-#~ msgid ""
-#~ "The keybinding you chose for \"Paste\" is invalid. Please choose another."
-#~ msgstr ""
-#~ "La scorciatoia da tastiera scelta per \"Incolla\" non è valida. "
 #~ "Selezionarne un'altra."
 
 #~ msgid ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2014-06-16 09:53+0200\n"
 "Last-Translator: Algimantas Margevičius <algimantas@margevicius.lt>\n"
 "Language-Team: Lithuanian <lt@li.org>\n"
@@ -12,6 +12,39 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2012-08-07 14:16+0000\n"
 "X-Generator: Poedit 1.6.5\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr "_Nauja kortelė"
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr "_Užverti kortelę"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+#, fuzzy
+msgid "_Toggle Fullscreen"
+msgstr "<b>Perjungti viso ekrano veikseną</b>"
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 msgid "Close Tilda"
@@ -25,19 +58,19 @@ msgstr "Atverti naują terminalą"
 msgid "Open a new terminal and hide"
 msgstr "Atverti naują terminalą ir paslėpti"
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr "Viršus"
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr "Apačioje"
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr "Kairėje"
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr "Dešinėje"
 
@@ -67,106 +100,106 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
-msgstr "Nerodoma"
-
-#: src/tilda.ui:143
-msgid "Goes after initial title"
-msgstr "Po pradinės antraštės"
-
-#: src/tilda.ui:146
-msgid "Goes before initial title"
-msgstr "Prieš pradinę antraštę"
-
-#: src/tilda.ui:149
-msgid "Replace initial title"
-msgstr "Pakeisti pradinę antraštę"
-
-#: src/tilda.ui:160
-msgid "Drop to the default shell"
-msgstr "Rodyti pagrindiniame „shell“"
-
-#: src/tilda.ui:163
-msgid "Restart the command"
-msgstr "Paleisti komandą iš naujo"
-
-#: src/tilda.ui:166
-msgid "Exit the terminal"
-msgstr "Išeiti iš terminalo"
-
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
-msgid "Custom"
-msgstr "Tinkintas"
-
-#: src/tilda.ui:200
-msgid "Green on Black"
-msgstr "Žalia ant juodos"
-
-#: src/tilda.ui:203
-msgid "Black on White"
-msgstr "Juoda ant balto"
-
-#: src/tilda.ui:206
-msgid "White on Black"
-msgstr "Balta ant juodos"
-
-#: src/tilda.ui:209 src/wizard.c:223
-msgid "Zenburn"
-msgstr "Zenburn"
-
-#: src/tilda.ui:212 src/wizard.c:224
-msgid "Solarized Light"
-msgstr "Išblukus spalva"
-
-#: src/tilda.ui:215 src/wizard.c:225
-msgid "Solarized Dark"
-msgstr "Išblukus juoda"
-
-#: src/tilda.ui:218 src/wizard.c:226
-msgid "Snazzy"
-msgstr ""
-
-#: src/tilda.ui:240
-msgid "On the Left"
-msgstr "Kairėje"
-
-#: src/tilda.ui:243
-msgid "On the Right"
-msgstr "Dešinėje"
-
-#: src/tilda.ui:246
-msgid "Disabled"
-msgstr "Išjungtas"
-
-#: src/tilda.ui:257 src/tilda.ui:274
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: src/tilda.ui:260 src/tilda.ui:277
-msgid "Escape sequence"
-msgstr "„Escape“ seka"
-
-#: src/tilda.ui:263 src/tilda.ui:280
-msgid "Control-H"
-msgstr "Vald-H"
-
-#: src/tilda.ui:291
 msgid "Show whole tab title"
 msgstr ""
 
-#: src/tilda.ui:294
+#: src/tilda.ui:143
 msgid "Show first n chars of title"
 msgstr ""
 
-#: src/tilda.ui:297
+#: src/tilda.ui:146
 msgid "Show last n chars of title"
 msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr "Nerodoma"
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr "Po pradinės antraštės"
+
+#: src/tilda.ui:163
+msgid "Goes before initial title"
+msgstr "Prieš pradinę antraštę"
+
+#: src/tilda.ui:166
+msgid "Replace initial title"
+msgstr "Pakeisti pradinę antraštę"
+
+#: src/tilda.ui:177
+msgid "Drop to the default shell"
+msgstr "Rodyti pagrindiniame „shell“"
+
+#: src/tilda.ui:180
+msgid "Restart the command"
+msgstr "Paleisti komandą iš naujo"
+
+#: src/tilda.ui:183
+msgid "Exit the terminal"
+msgstr "Išeiti iš terminalo"
+
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
+msgid "Custom"
+msgstr "Tinkintas"
+
+#: src/tilda.ui:217
+msgid "Green on Black"
+msgstr "Žalia ant juodos"
+
+#: src/tilda.ui:220
+msgid "Black on White"
+msgstr "Juoda ant balto"
+
+#: src/tilda.ui:223
+msgid "White on Black"
+msgstr "Balta ant juodos"
+
+#: src/tilda.ui:226 src/wizard.c:223
+msgid "Zenburn"
+msgstr "Zenburn"
+
+#: src/tilda.ui:229 src/wizard.c:224
+msgid "Solarized Light"
+msgstr "Išblukus spalva"
+
+#: src/tilda.ui:232 src/wizard.c:225
+msgid "Solarized Dark"
+msgstr "Išblukus juoda"
+
+#: src/tilda.ui:235 src/wizard.c:226
+msgid "Snazzy"
+msgstr ""
+
+#: src/tilda.ui:257
+msgid "On the Left"
+msgstr "Kairėje"
+
+#: src/tilda.ui:260
+msgid "On the Right"
+msgstr "Dešinėje"
+
+#: src/tilda.ui:263
+msgid "Disabled"
+msgstr "Išjungtas"
+
+#: src/tilda.ui:274 src/tilda.ui:291
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: src/tilda.ui:277 src/tilda.ui:294
+msgid "Escape sequence"
+msgstr "„Escape“ seka"
+
+#: src/tilda.ui:280 src/tilda.ui:297
+msgid "Control-H"
+msgstr "Vald-H"
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr "Tildos Konfigūracija"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Paleisti Tildą paslėptą"
 
@@ -199,72 +232,68 @@ msgstr "Perjungti viso ekrano veikseną"
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>Lango rodymas</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr "Kursoriaus mirgėjimas"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr "Girdimas Terminalo Skambutis"
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Terminalo rodymas</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "Įgalinti glodinimą"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "Leisti paryškintą tekstą"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "Šriftas:"
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Šriftas</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr "Pelei palikus Tilda paslėpti"
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr "Automatinio slėpimo delsa:"
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr "Slėpti kai Tilda praranda fokusą"
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Automatinis slėpimas</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr "Užvėrus paskutinį terminalą:"
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Visada viršuje"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 msgid "<b>Program Exit</b>"
 msgstr "<b>Programos išėjimas</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
@@ -272,67 +301,67 @@ msgstr ""
 "<small><i><b>Pastaba:</b> Kai kurios parinktys įsigalios tik iš naujo "
 "paleidus „tilda“.</i></small>"
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "Bendra"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr "Žodžių simboliai:"
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr "<b>Pasirinkti pagal žodį</b>"
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 msgid "Web Browser *:"
 msgstr "Naršyklė *:"
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr "<b>Adresų valdyklė</b>"
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Terminalo pavadinimas"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Dinamiškai nustatyti pavadinimą:"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Pavadinimas</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr "Paleisti komandą vietoj Shell'o"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "Komanda:"
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr "Kai komanda \"Exit\":"
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Komanda</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -344,134 +373,130 @@ msgstr ""
 "bendrines komandas „x-www-browser“ ir „xdg-open“. Kiekvienai sistemai "
 "geriausia komanda yra skirtinga."
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 #, fuzzy
 msgid "Close Action"
 msgstr "Užverti tilda"
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Pavadinimas ir komanda"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Procentais"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "Taškais"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Aukštis</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr "Monitorius:"
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 msgid "<b>Select monitor</b>"
 msgstr "<b>Pasirinkite monitorių</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Plotis</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Centruotas horizontaliai"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Y padėtis"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "X padėtis"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Centruotas vertikaliai"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Padėtis</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr "Kortelių pozicija:"
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Pridėti kortelę</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Animacijos delsa (ms)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Animacijos orientacija"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Fonui naudoti paveikslėlį"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Animuotas nusileidimas"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Permatomumo lygis"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Įjungti permatomumą"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Papildomi</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Išvaizda"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 #, fuzzy
 msgid "Cursor Color"
 msgstr "Kursoriaus mirgėjimas"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "Teksto spalva"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "Fono spalva"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr "Esamos schemos"
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr "<b>Priekinio ir galinio fono spalvos </b>"
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
@@ -479,128 +504,124 @@ msgstr ""
 "<small><i><b>Pastaba:</b> Terminalinėms programoms yra prieinamos šios "
 "spalvos.</i></small>"
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 msgid "Built-in schemes:"
 msgstr "Esamos schemos:"
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr "Spalvų paletė:"
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 msgid "<b>Palette</b>"
 msgstr "<b>Paletė</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Spalvos"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "Slinkimo juosta yra:"
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 #, fuzzy
 msgid "Limit scrollback to:"
 msgstr "Slinkimas:"
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "Slinkti išvestyje"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr "Slinkti paspaudus klavišą"
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "Slinkti foną"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "eilučių"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>Slinkimas</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Slinkimas"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -612,53 +633,53 @@ msgstr ""
 "programų ir operacinių sistemų, kurios tikisi kitokio terminalo veikimo, "
 "elgseną.</i></small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr "„_Backspace“ klavišas siunčia:"
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr "„_Delete“ klavišas siunčia:"
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Atstatyti suderinamumo nustatymus į numatytuosius"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>Suderinamumas</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Suderinamumas"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "Klavišų susaistymai"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "Klavišų susaistymai"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -680,61 +701,53 @@ msgstr "Negalima įrašyti į konfigūravimo failą %s\n"
 msgid "Unable to run command: `%s'\n"
 msgstr "Negalima paleisit komandos: `%s'\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr "Negalima atidaryti užrakinto katalogo: %s\n"
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "Naudoti šriftus su taškine korekcija"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Nustatyti fono spalvą"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Paleisti komandą pasileidus"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Nustatyti šriftą sekančiai eilutei"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Rodyti konfiguravimo vediklį"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "Slinkimo eilutės"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "Naudoti slankjuostę"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Parodyti versiją, tada išeiti"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "Nustatyti pradinį darbo katalogą"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Nustatyti fono paveikslėlį"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "Neskaidrumas: 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "Rodyti konfiguravimo vediklį"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -747,7 +760,7 @@ msgstr ""
 "\n"
 "Klaidos žinutė: %s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, fuzzy, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -761,32 +774,32 @@ msgstr ""
 "\n"
 "Klaidos žinutė: %s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr "Kuriamas aplankas: „%s“\n"
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 "Naudotojo konfigūracijos aplanke rasta „style.css“, pritaikomas naudotojo "
 "stilius.\n"
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr "Perkeliamas senas konfigūracijos kelias į XDG aplankus\n"
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
@@ -794,40 +807,60 @@ msgstr ""
 "Jūsų pasirinktas klavišų susiejimas skirtas „Išskleisti terminalą“ yra "
 "netinkamas. Pasirinkite kitą."
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+#, fuzzy
+msgid "Action"
+msgstr "Užverti tilda"
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr "Įveskite klaviatūros greitąjį klavišą"
+
+#: src/tilda-keybinding.c:417
+#, fuzzy, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+"Jūsų pasirinktas klavišų susiejimas skirtas „Įklijuoti“ yra netinkamas. "
+"Pasirinkite kitą."
+
+#: src/tilda_terminal.c:397
 #, fuzzy, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr "Klaida analizuojant komandą: %s\n"
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr "Klaida analizuojant komandą: %s\n"
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr "Paleisti numatytąją konsolę vietoj\n"
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr "Nepavyko paleisti komandos: %s\n"
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr "Negalima paleisti numatytosios konsolės: %s\n"
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr "Nepavyko paleisti interneto naršyklės. Komanda buvo `%s'\n"
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "Be pavadinimo"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr "Bloga reikšmė \"d_set_title\" konfigūracijos faile\n"
 
@@ -839,16 +872,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr "Jūs turite blogai nustatytą tab_pos konfigūracijos faile\n"
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "Negalima nustatyti Tildos piktogramos: %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "Trūksta atminties, negalima sukurti kortelės\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -868,22 +901,37 @@ msgstr "XTerm"
 msgid "Rxvt"
 msgstr "Rxvt"
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, c-format
 msgid "Tilda %d Config"
 msgstr "Tildos %d konfigūracija"
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr "Neteisinga kortelės pozicijos nuostata, ignoruojama\n"
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "Įgalinti glodinimą"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Fonui naudoti paveikslėlį"
+
+#~ msgid "Scroll Background"
+#~ msgstr "Slinkti foną"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "Naudoti šriftus su taškine korekcija"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Nustatyti fono paveikslėlį"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Įgalinti dvigubą buferį"
@@ -954,20 +1002,11 @@ msgstr "Neteisinga kortelės pozicijos nuostata, ignoruojama\n"
 #~ msgid "<b>Move Tab Right</b>"
 #~ msgstr "<b>Perkelti kortelę dešinėn</b>"
 
-#~ msgid "<b>Toggle Fullscreen</b>"
-#~ msgstr "<b>Perjungti viso ekrano veikseną</b>"
-
 #~ msgid "Problem when opening config file\n"
 #~ msgstr "Klaida atveriant konfigūracijos failą\n"
 
 #~ msgid "An unexpected error occured while parsing the config file\n"
 #~ msgstr "Apdorojant konfigūracijos failą įvyko nežinoma klaida\n"
-
-#~ msgid "_New Tab"
-#~ msgstr "_Nauja kortelė"
-
-#~ msgid "_Close Tab"
-#~ msgstr "_Užverti kortelę"
 
 #~ msgid ""
 #~ "The keybinding you chose for \"Add Tab\" is invalid. Please choose "
@@ -1015,12 +1054,6 @@ msgstr "Neteisinga kortelės pozicijos nuostata, ignoruojama\n"
 #~ "The keybinding you chose for \"Copy\" is invalid. Please choose another."
 #~ msgstr ""
 #~ "Jūsų pasirinktas klavišų susiejimas skirtas „Kopijuoti“ yra netinkamas. "
-#~ "Pasirinkite kitą."
-
-#~ msgid ""
-#~ "The keybinding you chose for \"Paste\" is invalid. Please choose another."
-#~ msgstr ""
-#~ "Jūsų pasirinktas klavišų susiejimas skirtas „Įklijuoti“ yra netinkamas. "
 #~ "Pasirinkite kitą."
 
 #~ msgid ""
@@ -1105,9 +1138,6 @@ msgstr "Neteisinga kortelės pozicijos nuostata, ignoruojama\n"
 #~ msgstr ""
 #~ "Jūsų pasirinktas klavišų susiejimas skirtas „Perjungti viso ekrano "
 #~ "veikseną“ yra netinkamas. Pasirinkite kitą."
-
-#~ msgid "Enter keyboard shortcut"
-#~ msgstr "Įveskite klaviatūros greitąjį klavišą"
 
 #~ msgid "Problem while parsing config file\n"
 #~ msgstr "Apdorojant konfigūracijos failą įvyko klaida\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2008-03-06 00:10+0000\n"
 "Last-Translator: Maciej Habant <Unknown>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -17,6 +17,38 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr "_Nowa karta"
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr "_Zamknij kartę"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 #, fuzzy
@@ -31,19 +63,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -73,84 +105,96 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
+msgid "Show whole tab title"
 msgstr ""
 
 #: src/tilda.ui:143
-msgid "Goes after initial title"
+msgid "Show first n chars of title"
 msgstr ""
 
 #: src/tilda.ui:146
+msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
 msgid "Goes before initial title"
 msgstr ""
 
-#: src/tilda.ui:149
+#: src/tilda.ui:166
 #, fuzzy
 msgid "Replace initial title"
 msgstr "Początkowy tytuł"
 
-#: src/tilda.ui:160
+#: src/tilda.ui:177
 #, fuzzy
 msgid "Drop to the default shell"
 msgstr "Nie można uruchomić domyślnej powłoki: %s\n"
 
-#: src/tilda.ui:163
+#: src/tilda.ui:180
 msgid "Restart the command"
 msgstr ""
 
-#: src/tilda.ui:166
+#: src/tilda.ui:183
 msgid "Exit the terminal"
 msgstr ""
 
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
 msgid "Custom"
 msgstr ""
 
-#: src/tilda.ui:200
+#: src/tilda.ui:217
 msgid "Green on Black"
 msgstr ""
 
-#: src/tilda.ui:203
+#: src/tilda.ui:220
 msgid "Black on White"
 msgstr ""
 
-#: src/tilda.ui:206
+#: src/tilda.ui:223
 msgid "White on Black"
 msgstr ""
 
-#: src/tilda.ui:209 src/wizard.c:223
+#: src/tilda.ui:226 src/wizard.c:223
 msgid "Zenburn"
 msgstr ""
 
-#: src/tilda.ui:212 src/wizard.c:224
+#: src/tilda.ui:229 src/wizard.c:224
 msgid "Solarized Light"
 msgstr ""
 
-#: src/tilda.ui:215 src/wizard.c:225
+#: src/tilda.ui:232 src/wizard.c:225
 msgid "Solarized Dark"
 msgstr ""
 
-#: src/tilda.ui:218 src/wizard.c:226
+#: src/tilda.ui:235 src/wizard.c:226
 msgid "Snazzy"
 msgstr ""
 
-#: src/tilda.ui:240
+#: src/tilda.ui:257
 msgid "On the Left"
 msgstr ""
 
-#: src/tilda.ui:243
+#: src/tilda.ui:260
 msgid "On the Right"
 msgstr ""
 
-#: src/tilda.ui:246
+#: src/tilda.ui:263
 msgid "Disabled"
 msgstr ""
 
-#: src/tilda.ui:257 src/tilda.ui:274
+#: src/tilda.ui:274 src/tilda.ui:291
 msgid "ASCII DEL"
 msgstr ""
 
-#: src/tilda.ui:260 src/tilda.ui:277
+#: src/tilda.ui:277 src/tilda.ui:294
 #, fuzzy
 msgid "Escape sequence"
 msgstr ""
@@ -158,20 +202,8 @@ msgstr ""
 "Sekwencja sterująca\n"
 "Control-H"
 
-#: src/tilda.ui:263 src/tilda.ui:280
+#: src/tilda.ui:280 src/tilda.ui:297
 msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
-msgid "Show whole tab title"
-msgstr ""
-
-#: src/tilda.ui:294
-msgid "Show first n chars of title"
-msgstr ""
-
-#: src/tilda.ui:297
-msgid "Show last n chars of title"
 msgstr ""
 
 #: src/tilda.ui:314
@@ -179,7 +211,7 @@ msgstr ""
 msgid "Tilda Config"
 msgstr "Konfiguracja"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Uruchamiaj Tildę ukrytą"
 
@@ -211,143 +243,139 @@ msgstr ""
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 #, fuzzy
 msgid "<b>Window Display</b>"
 msgstr "<b>Ekran Okna</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr "Mruganie kursora"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr "Głośny dzwonek terminala"
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 #, fuzzy
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Ekran Terminalu</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "Włącz antyaliasing"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "Pozwól na pogrubioną czcionkę"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "Czcionka:"
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Czcionka</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr ""
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr ""
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr ""
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 #, fuzzy
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Tytuł</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Zawsze na wierzchu"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 #, fuzzy
 msgid "<b>Program Exit</b>"
 msgstr "<b>Pozycja</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "Ogólne"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr ""
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr ""
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 #, fuzzy
 msgid "Web Browser *:"
 msgstr "Przeglądarka WWW"
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr "<b>Obsługa URLi</b>"
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Początkowy tytuł"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Dynamicznie ustawiony tytuł"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Tytuł</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr "Uruchom własne plecenie zamiast powłoki"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "Własne polecenie:"
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr ""
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Polecenie</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -355,264 +383,256 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 #, fuzzy
 msgid "Close Action"
 msgstr "_Zamknij kartę"
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Tytuł i polecenie"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Procent"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "W pikselach"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Wysokość</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 #, fuzzy
 msgid "<b>Select monitor</b>"
 msgstr "<b>Tytuł</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Szerokość</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Wyśrodkowanie poziome"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Pozycja Y"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "Pozycja X"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Wyśrodkowanie pionowe"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Pozycja</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr ""
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Tytuł</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 #, fuzzy
 msgid "Animation Delay (usec)"
 msgstr "Opóźnienie animacji (milisekundy)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Orientacja animacji"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Użyj obrazu jako tła"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Animowane rozwijanie"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Poziom przezroczystości"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Włącz przezroczystość"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Dodatkowe</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Wygląd"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 #, fuzzy
 msgid "Cursor Color"
 msgstr "Mruganie kursora"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "Kolor tekstu"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "Kolor tła"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr "Wbudowane schematy"
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr ""
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 #, fuzzy
 msgid "Built-in schemes:"
 msgstr "Wbudowane schematy"
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr ""
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 #, fuzzy
 msgid "<b>Palette</b>"
 msgstr "<b>Tytuł</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Kolory"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "Pasek przewijania jest:"
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 msgid "Limit scrollback to:"
 msgstr ""
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr ""
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr "Przewijaj po naciśnięciu klawisza"
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "Przewijaj tło"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "wiersze"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>Przewijanie</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Przewijanie"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -624,53 +644,53 @@ msgstr ""
 "z pewnymi aplikacjami i systemami operacyjnymi, które oczekują innego "
 "zachowania terminala.</i></small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr "Klawisz _Backspace generuje:"
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr "Klawisz _Delete generuje:"
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "Przywróć _domyślne wartości opcji zgodności"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>Kompatybilność</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Kompatybilność"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "Skróty klawiszowe"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "Skróty klawiszowe"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -692,63 +712,55 @@ msgstr "Nie można zapisać pliku konfiguracyjnego do %s\n"
 msgid "Unable to run command: `%s'\n"
 msgstr "Nie można wykonać polecenia: `%s'\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr ""
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "Włącz anti-aliasing czcionek"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Ustaw kolor tła"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Wykonaj polecenie przy starcie"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Ustaw czcionkę do następującego ciągu"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Pokaż kreatora ustawień"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "Ilość przewijanych wierszy"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "Włącz pasek przewijania"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Wyświetl wersję i zakończ"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 #, fuzzy
 msgid "Set Initial Working Directory"
 msgstr "Ustaw katalog startowy"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Ustaw obraz jako tło"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "Nieprzeźroczystość: 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 #, fuzzy
 msgid "Show Configuration Wizard"
 msgstr "Pokaż kreatora ustawień"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -761,7 +773,7 @@ msgstr ""
 "\n"
 "Treść błędu: %s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, fuzzy, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -775,30 +787,30 @@ msgstr ""
 "\n"
 "Treść błędu: %s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 #, fuzzy
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
@@ -806,41 +818,60 @@ msgid ""
 msgstr ""
 "Przypisanie klawiszy, które wybrałeś jest nieprawidłowe. Proszę wybrać inne."
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+#, fuzzy
+msgid "Action"
+msgstr "_Zamknij kartę"
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, fuzzy, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+"Przypisanie klawiszy, które wybrałeś jest nieprawidłowe. Proszę wybrać inne."
+
+#: src/tilda_terminal.c:397
 #, fuzzy, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr "Problem przy parsowaniu własnej komendy: %s\n"
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, fuzzy, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr "Problem przy parsowaniu własnej komendy: %s\n"
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr "Zamiast tego uruchamiem domyślną powłokę\n"
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr "Nie można uruchomić własnej komeny: %s\n"
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr "Nie można uruchomić domyślnej powłoki: %s\n"
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr "Nie udało się uruchomić przeglądarki. Wywołano komendę `%s'\n"
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 #, fuzzy
 msgid "Untitled"
 msgstr "Bez nazwy"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr "Zła wartość \"d_set_title\" w pliku konfiguracyjnym\n"
 
@@ -852,16 +883,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr "Powinieneś mieć złą wartość tab_pos w swoim pliku konfiguracyjnym\n"
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, fuzzy, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "Nie można ustawić ikony tildy: %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "Zbyt mało pamięci do utworzenia nowej zakładki\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -881,22 +912,37 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, fuzzy, c-format
 msgid "Tilda %d Config"
 msgstr "Konfiguracja"
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr "Nieprawidłowe ustawienie pozycji karty, ignorowanie\n"
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "Włącz antyaliasing"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Użyj obrazu jako tła"
+
+#~ msgid "Scroll Background"
+#~ msgstr "Przewijaj tło"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "Włącz anti-aliasing czcionek"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Ustaw obraz jako tło"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Włącz podwójne buforowanie"
@@ -935,12 +981,6 @@ msgstr "Nieprawidłowe ustawienie pozycji karty, ignorowanie\n"
 #, fuzzy
 #~ msgid "Problem when opening config file\n"
 #~ msgstr "Problem przy parsowaniu pliku konfiguracyjnego\n"
-
-#~ msgid "_New Tab"
-#~ msgstr "_Nowa karta"
-
-#~ msgid "_Close Tab"
-#~ msgstr "_Zamknij kartę"
 
 #, fuzzy
 #~ msgid ""
@@ -993,13 +1033,6 @@ msgstr "Nieprawidłowe ustawienie pozycji karty, ignorowanie\n"
 #, fuzzy
 #~ msgid ""
 #~ "The keybinding you chose for \"Copy\" is invalid. Please choose another."
-#~ msgstr ""
-#~ "Przypisanie klawiszy, które wybrałeś jest nieprawidłowe. Proszę wybrać "
-#~ "inne."
-
-#, fuzzy
-#~ msgid ""
-#~ "The keybinding you chose for \"Paste\" is invalid. Please choose another."
 #~ msgstr ""
 #~ "Przypisanie klawiszy, które wybrałeś jest nieprawidłowe. Proszę wybrać "
 #~ "inne."

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2008-04-19 11:22+0000\n"
 "Last-Translator: João Santos <twocool.pt@gmail.com>\n"
 "Language-Team: Portuguese <pt@li.org>\n"
@@ -17,6 +17,38 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr "_Nova Aba"
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr "_Fechar Aba"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 #, fuzzy
@@ -31,19 +63,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -73,84 +105,96 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
+msgid "Show whole tab title"
 msgstr ""
 
 #: src/tilda.ui:143
-msgid "Goes after initial title"
+msgid "Show first n chars of title"
 msgstr ""
 
 #: src/tilda.ui:146
+msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
 msgid "Goes before initial title"
 msgstr ""
 
-#: src/tilda.ui:149
+#: src/tilda.ui:166
 #, fuzzy
 msgid "Replace initial title"
 msgstr "Título Inicial:"
 
-#: src/tilda.ui:160
+#: src/tilda.ui:177
 #, fuzzy
 msgid "Drop to the default shell"
 msgstr "Incapaz de carregar o shell padrão: %s\n"
 
-#: src/tilda.ui:163
+#: src/tilda.ui:180
 msgid "Restart the command"
 msgstr ""
 
-#: src/tilda.ui:166
+#: src/tilda.ui:183
 msgid "Exit the terminal"
 msgstr ""
 
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
 msgid "Custom"
 msgstr ""
 
-#: src/tilda.ui:200
+#: src/tilda.ui:217
 msgid "Green on Black"
 msgstr ""
 
-#: src/tilda.ui:203
+#: src/tilda.ui:220
 msgid "Black on White"
 msgstr ""
 
-#: src/tilda.ui:206
+#: src/tilda.ui:223
 msgid "White on Black"
 msgstr ""
 
-#: src/tilda.ui:209 src/wizard.c:223
+#: src/tilda.ui:226 src/wizard.c:223
 msgid "Zenburn"
 msgstr ""
 
-#: src/tilda.ui:212 src/wizard.c:224
+#: src/tilda.ui:229 src/wizard.c:224
 msgid "Solarized Light"
 msgstr ""
 
-#: src/tilda.ui:215 src/wizard.c:225
+#: src/tilda.ui:232 src/wizard.c:225
 msgid "Solarized Dark"
 msgstr ""
 
-#: src/tilda.ui:218 src/wizard.c:226
+#: src/tilda.ui:235 src/wizard.c:226
 msgid "Snazzy"
 msgstr ""
 
-#: src/tilda.ui:240
+#: src/tilda.ui:257
 msgid "On the Left"
 msgstr ""
 
-#: src/tilda.ui:243
+#: src/tilda.ui:260
 msgid "On the Right"
 msgstr ""
 
-#: src/tilda.ui:246
+#: src/tilda.ui:263
 msgid "Disabled"
 msgstr ""
 
-#: src/tilda.ui:257 src/tilda.ui:274
+#: src/tilda.ui:274 src/tilda.ui:291
 msgid "ASCII DEL"
 msgstr ""
 
-#: src/tilda.ui:260 src/tilda.ui:277
+#: src/tilda.ui:277 src/tilda.ui:294
 #, fuzzy
 msgid "Escape sequence"
 msgstr ""
@@ -158,27 +202,15 @@ msgstr ""
 "Sequência de escape\n"
 "Control-H"
 
-#: src/tilda.ui:263 src/tilda.ui:280
+#: src/tilda.ui:280 src/tilda.ui:297
 msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
-msgid "Show whole tab title"
-msgstr ""
-
-#: src/tilda.ui:294
-msgid "Show first n chars of title"
-msgstr ""
-
-#: src/tilda.ui:297
-msgid "Show last n chars of title"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr "Configuração do Tilda"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Iniciar o Tilda escondido"
 
@@ -210,141 +242,137 @@ msgstr ""
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>Exibição da Janela</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr "Cursor Pisca"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr "Campainha do Terminal Audível"
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Exibição do Terminal</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "Habilitar Antiserrilhado"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "Permitir Texto em Negrito"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "Tipo de letra:"
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Fonte</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr ""
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr ""
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr ""
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 #, fuzzy
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Título</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Sempre no topo"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 #, fuzzy
 msgid "<b>Program Exit</b>"
 msgstr "<b>Posição</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "Geral"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr ""
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr ""
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 #, fuzzy
 msgid "Web Browser *:"
 msgstr "Navegador Web"
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr "<b>Tratamento de URL</b>"
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Título Inicial:"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Título definido dinamicamente:"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Título</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr "Correr um comando personalizado em vez da shell"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "Comando personalizado:"
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr "Quando o comando sair:"
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Comando</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -352,264 +380,256 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 #, fuzzy
 msgid "Close Action"
 msgstr "_Fechar Aba"
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Título e Comando"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Percentagem"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "Em Pixeis"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Altura</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 #, fuzzy
 msgid "<b>Select monitor</b>"
 msgstr "<b>Título</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Comprimento</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Centrado Horizontalmente"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Posição Y"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "Posição X"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Centrado Verticalmente"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Posição</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr "Posição das Abas"
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Título</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Atraso da Animação (usec)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Orientação de Animação"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Usar imagem de fundo"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Animação"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Nivel de Transparência"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Habilitar Transparência"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Extras</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Aparência"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 #, fuzzy
 msgid "Cursor Color"
 msgstr "Cursor Pisca"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "Cor do Texto"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "Cor de Fundo"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr "Esquemas Pre-definidos"
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr "<b>Cores de Frente e Fundo</b>"
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 #, fuzzy
 msgid "Built-in schemes:"
 msgstr "Esquemas Pre-definidos"
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr ""
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 #, fuzzy
 msgid "<b>Palette</b>"
 msgstr "<b>Título</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Cores"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "Barra de Rolamento está à:"
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 #, fuzzy
 msgid "Limit scrollback to:"
 msgstr "Histórico:"
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "Rolar com o conteúdo"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr "Rodar ao Pressionar Tecla"
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "Rolar fundo"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "linhas"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>Rolamento</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Rolamento"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -621,53 +641,53 @@ msgstr ""
 "algumas aplicações e sistemas operativos que esperam comportamentos "
 "diferentes da consola.</i></small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr "Tecla _backspace gera:"
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr "Tecla _delete gera:"
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Repor Opções de Compatibilidade nos Valores Pre-definidos"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>Compatibilidade</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Compatibilidade"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "Atalhos de Teclado"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "Atalhos de Teclado"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -691,61 +711,53 @@ msgstr "Não foi possível escrever o ficheiro de configuração para %s\n"
 msgid "Unable to run command: `%s'\n"
 msgstr "Não foi possível correr o comando: '%s'\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr "Não foi possível abrir directório de bloqueio: %s\n"
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "Usar fontes não serrilhadas"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Definir a cor de fundo"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Corre um comando ao iniciar"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Definir a fonte da seguinte expressão"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Mostrar o Assistente de Configuração"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "Linhas do Histórico"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "Usar Barra de Rolamento"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Escreve a versão e sai"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "Definir o Directório de Trabalho Inicial"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Definir a imagem de fundo"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "Opacidade: 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "Mostrar o Assistente de Configuração"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -758,7 +770,7 @@ msgstr ""
 "\n"
 "Mensagem de erro: %s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, fuzzy, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -772,30 +784,30 @@ msgstr ""
 "\n"
 "Mensagem de erro: %s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 #, fuzzy
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
@@ -803,40 +815,59 @@ msgid ""
 msgstr ""
 "A combinação de teclas que escolheu é inválida. Por favor escolha outra."
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+#, fuzzy
+msgid "Action"
+msgstr "_Fechar Aba"
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, fuzzy, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+"A combinação de teclas que escolheu é inválida. Por favor escolha outra."
+
+#: src/tilda_terminal.c:397
 #, fuzzy, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr "Problema ao analisar o comando personalizado: %s\n"
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr "Problema ao analisar o comando personalizado: %s\n"
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr "Carregando antes a shell padrão\n"
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr "Incapaz de carregar o comando personalizado: %s\n"
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr "Incapaz de carregar o shell padrão: %s\n"
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr "Falha ao carregar o navegador web. O comando foi `%s'\n"
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "Sem título"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr "Valor inválido para \"d_set_title\" no ficheiro de configuração\n"
 
@@ -848,16 +879,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr "Tem um tab_pos errado no seu ficheiro de configuração\n"
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "Não foi possível mudar o ícone do tilda: %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "Memória Insuficiente, não é possível criar aba\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -877,22 +908,37 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, fuzzy, c-format
 msgid "Tilda %d Config"
 msgstr "Configuração do Tilda"
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr "Configuração de posição de aba inválida, ignorando\n"
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "Habilitar Antiserrilhado"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Usar imagem de fundo"
+
+#~ msgid "Scroll Background"
+#~ msgstr "Rolar fundo"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "Usar fontes não serrilhadas"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Definir a imagem de fundo"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Habilitar Buffering Duplo"
@@ -931,12 +977,6 @@ msgstr "Configuração de posição de aba inválida, ignorando\n"
 #, fuzzy
 #~ msgid "Problem when opening config file\n"
 #~ msgstr "Problema ao analisar o arquivo de configuração\n"
-
-#~ msgid "_New Tab"
-#~ msgstr "_Nova Aba"
-
-#~ msgid "_Close Tab"
-#~ msgstr "_Fechar Aba"
 
 #, fuzzy
 #~ msgid ""
@@ -983,12 +1023,6 @@ msgstr "Configuração de posição de aba inválida, ignorando\n"
 #, fuzzy
 #~ msgid ""
 #~ "The keybinding you chose for \"Copy\" is invalid. Please choose another."
-#~ msgstr ""
-#~ "A combinação de teclas que escolheu é inválida. Por favor escolha outra."
-
-#, fuzzy
-#~ msgid ""
-#~ "The keybinding you chose for \"Paste\" is invalid. Please choose another."
 #~ msgstr ""
 #~ "A combinação de teclas que escolheu é inválida. Por favor escolha outra."
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,13 +7,45 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2014-08-04 22:29+0000\n"
 "Last-Translator: NatanJMai <natan.mai@hotmail.com>\n"
 "Language: pt_BR\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr "_Nova Aba"
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr "_Fechar Aba"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 msgid "Close Tilda"
@@ -27,19 +59,19 @@ msgstr "Abrir um novo terminal"
 msgid "Open a new terminal and hide"
 msgstr "Abrir um novo terminal e esconder"
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr "Topo"
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr "Inferior"
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr "Esquerda"
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr "Direita"
 
@@ -69,106 +101,106 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
-msgstr "Não é exibido"
-
-#: src/tilda.ui:143
-msgid "Goes after initial title"
-msgstr "Após o título inicial"
-
-#: src/tilda.ui:146
-msgid "Goes before initial title"
-msgstr "Antes do título inicial"
-
-#: src/tilda.ui:149
-msgid "Replace initial title"
-msgstr "Substituir título inicial"
-
-#: src/tilda.ui:160
-msgid "Drop to the default shell"
-msgstr "Alterar para o shell padrão"
-
-#: src/tilda.ui:163
-msgid "Restart the command"
-msgstr "Reiniciar o comando"
-
-#: src/tilda.ui:166
-msgid "Exit the terminal"
-msgstr "Fechar o terminal"
-
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
-msgid "Custom"
-msgstr "Personalizado"
-
-#: src/tilda.ui:200
-msgid "Green on Black"
-msgstr "Verde no Preto"
-
-#: src/tilda.ui:203
-msgid "Black on White"
-msgstr "Preto no Branco"
-
-#: src/tilda.ui:206
-msgid "White on Black"
-msgstr "Branco no Preto"
-
-#: src/tilda.ui:209 src/wizard.c:223
-msgid "Zenburn"
-msgstr "Zenburn"
-
-#: src/tilda.ui:212 src/wizard.c:224
-msgid "Solarized Light"
-msgstr "Luz solarizada"
-
-#: src/tilda.ui:215 src/wizard.c:225
-msgid "Solarized Dark"
-msgstr "Escuro solarizado"
-
-#: src/tilda.ui:218 src/wizard.c:226
-msgid "Snazzy"
-msgstr ""
-
-#: src/tilda.ui:240
-msgid "On the Left"
-msgstr "À esquerda"
-
-#: src/tilda.ui:243
-msgid "On the Right"
-msgstr "À direita"
-
-#: src/tilda.ui:246
-msgid "Disabled"
-msgstr "Inválido"
-
-#: src/tilda.ui:257 src/tilda.ui:274
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: src/tilda.ui:260 src/tilda.ui:277
-msgid "Escape sequence"
-msgstr ""
-
-#: src/tilda.ui:263 src/tilda.ui:280
-msgid "Control-H"
-msgstr "Control-H"
-
-#: src/tilda.ui:291
 msgid "Show whole tab title"
 msgstr ""
 
-#: src/tilda.ui:294
+#: src/tilda.ui:143
 msgid "Show first n chars of title"
 msgstr ""
 
-#: src/tilda.ui:297
+#: src/tilda.ui:146
 msgid "Show last n chars of title"
 msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr "Não é exibido"
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr "Após o título inicial"
+
+#: src/tilda.ui:163
+msgid "Goes before initial title"
+msgstr "Antes do título inicial"
+
+#: src/tilda.ui:166
+msgid "Replace initial title"
+msgstr "Substituir título inicial"
+
+#: src/tilda.ui:177
+msgid "Drop to the default shell"
+msgstr "Alterar para o shell padrão"
+
+#: src/tilda.ui:180
+msgid "Restart the command"
+msgstr "Reiniciar o comando"
+
+#: src/tilda.ui:183
+msgid "Exit the terminal"
+msgstr "Fechar o terminal"
+
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
+msgid "Custom"
+msgstr "Personalizado"
+
+#: src/tilda.ui:217
+msgid "Green on Black"
+msgstr "Verde no Preto"
+
+#: src/tilda.ui:220
+msgid "Black on White"
+msgstr "Preto no Branco"
+
+#: src/tilda.ui:223
+msgid "White on Black"
+msgstr "Branco no Preto"
+
+#: src/tilda.ui:226 src/wizard.c:223
+msgid "Zenburn"
+msgstr "Zenburn"
+
+#: src/tilda.ui:229 src/wizard.c:224
+msgid "Solarized Light"
+msgstr "Luz solarizada"
+
+#: src/tilda.ui:232 src/wizard.c:225
+msgid "Solarized Dark"
+msgstr "Escuro solarizado"
+
+#: src/tilda.ui:235 src/wizard.c:226
+msgid "Snazzy"
+msgstr ""
+
+#: src/tilda.ui:257
+msgid "On the Left"
+msgstr "À esquerda"
+
+#: src/tilda.ui:260
+msgid "On the Right"
+msgstr "À direita"
+
+#: src/tilda.ui:263
+msgid "Disabled"
+msgstr "Inválido"
+
+#: src/tilda.ui:274 src/tilda.ui:291
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: src/tilda.ui:277 src/tilda.ui:294
+msgid "Escape sequence"
+msgstr ""
+
+#: src/tilda.ui:280 src/tilda.ui:297
+msgid "Control-H"
+msgstr "Control-H"
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr "Configurações Tilda"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Iniciar escondido"
 
@@ -200,72 +232,68 @@ msgstr ""
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "Vitrine"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr "Efeito do cursor"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr "Som do terminal"
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Visor do terminal</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "Ativar suavização"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "Permitir texto em negrito"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "Fonte:"
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Fonte</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr "Ocultar Tilda quando mouse sair"
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr "Tempo para esconder automaticamente"
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr "Esconder Tilda quando perder o foco"
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Esconder Automaticamente</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr "Quando o último terminal é fechado:"
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Sempre no topo"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 msgid "<b>Program Exit</b>"
 msgstr "<b>Sair do Programa</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
@@ -273,67 +301,67 @@ msgstr ""
 "<small><i><b>Note:</b> Algumas opções requerem que o Tilda seja reiniciado.</"
 "i></small>"
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "Geral"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr "Caracteres:"
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr "<b>Selecione por palavra</b>"
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 msgid "Web Browser *:"
 msgstr "Navegador *:"
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr ""
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Título Inicial:"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr ""
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Título</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr "Executar um comando personalizado em vez do shell"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "Comando personalizado:"
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr "Quando o comando sair:"
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Comando</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -341,260 +369,252 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 #, fuzzy
 msgid "Close Action"
 msgstr "Fechar Tilda"
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Título e Comando"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Percentual"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "Em Pixels"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Altura</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr "Monitor:"
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 msgid "<b>Select monitor</b>"
 msgstr "<b>Selecione o monitor</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Largura</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Centralizado Horizontalmente"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Posição Y"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "Posição X"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Centralizado Verticalmente"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Posição</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr "Posições das abas"
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Adicionar Aba</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Tempo de animação"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Orientação da Animação"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Usar imagem como plano de fundo"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Animar a descida"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Nível de Transparência"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Habilitar Transparência"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Extras</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Aparência"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 #, fuzzy
 msgid "Cursor Color"
 msgstr "Efeito do cursor"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "Cor do Texto"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "Cor do plano de fundo"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr "Esquemas embutidos"
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr ""
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 msgid "Built-in schemes:"
 msgstr "Esquemas Embutidos:"
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr "Paleta de cores:"
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Cores"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr ""
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 msgid "Limit scrollback to:"
 msgstr ""
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr ""
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr ""
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr ""
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr "0"
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "Linhas"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr ""
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr ""
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -602,53 +622,53 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr ""
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "Voltar opções padrões de compatibilidade"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>Compatibilidade</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Compatibilidade"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "<b>Altura</b>"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr ""
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -670,60 +690,52 @@ msgstr ""
 msgid "Unable to run command: `%s'\n"
 msgstr ""
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr ""
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr ""
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Mudar a cor de fundo"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr ""
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Mudar a fonte para a seguinte frase"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 msgid "Configuration file"
 msgstr ""
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr ""
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr ""
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Mostrar a versão, quando fechado"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "Mudar Diretório de Trabalho inicial"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Alterar imagem de fundo"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr ""
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr ""
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -732,7 +744,7 @@ msgid ""
 "Error message: %s\n"
 msgstr ""
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -742,69 +754,87 @@ msgid ""
 "Error message: %s\n"
 msgstr ""
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr "Criando diretório:'%s'\n"
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
 msgstr ""
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+#, fuzzy
+msgid "Action"
+msgstr "Fechar Tilda"
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr "Adicione um atalho de teclado"
+
+#: src/tilda-keybinding.c:417
+#, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+
+#: src/tilda_terminal.c:397
 #, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr ""
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "Sem título"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr ""
 
@@ -816,16 +846,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr ""
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr ""
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr ""
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -845,22 +875,31 @@ msgstr "XTerm"
 msgid "Rxvt"
 msgstr "Rxvt"
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, c-format
 msgid "Tilda %d Config"
 msgstr ""
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr ""
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "Ativar suavização"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Usar imagem como plano de fundo"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Alterar imagem de fundo"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Ativar Double Buffering"
@@ -921,12 +960,3 @@ msgstr ""
 
 #~ msgid "<b>Go To Tab 9</b>"
 #~ msgstr "<b>Ir para a Aba 9</b>"
-
-#~ msgid "_New Tab"
-#~ msgstr "_Nova Aba"
-
-#~ msgid "_Close Tab"
-#~ msgstr "_Fechar Aba"
-
-#~ msgid "Enter keyboard shortcut"
-#~ msgstr "Adicione um atalho de teclado"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2008-02-09 09:14+0000\n"
 "Last-Translator: Anton Shestakov <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -17,6 +17,38 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr "_Новая вкладка"
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr "_Закрыть вкладку"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 #, fuzzy
@@ -31,19 +63,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -73,84 +105,96 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
+msgid "Show whole tab title"
 msgstr ""
 
 #: src/tilda.ui:143
-msgid "Goes after initial title"
+msgid "Show first n chars of title"
 msgstr ""
 
 #: src/tilda.ui:146
+msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
 msgid "Goes before initial title"
 msgstr ""
 
-#: src/tilda.ui:149
+#: src/tilda.ui:166
 #, fuzzy
 msgid "Replace initial title"
 msgstr "Исходный заголовок:"
 
-#: src/tilda.ui:160
+#: src/tilda.ui:177
 #, fuzzy
 msgid "Drop to the default shell"
 msgstr "Не удалось запустить оболочку по умолчанию: %s\n"
 
-#: src/tilda.ui:163
+#: src/tilda.ui:180
 msgid "Restart the command"
 msgstr ""
 
-#: src/tilda.ui:166
+#: src/tilda.ui:183
 msgid "Exit the terminal"
 msgstr ""
 
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
 msgid "Custom"
 msgstr ""
 
-#: src/tilda.ui:200
+#: src/tilda.ui:217
 msgid "Green on Black"
 msgstr ""
 
-#: src/tilda.ui:203
+#: src/tilda.ui:220
 msgid "Black on White"
 msgstr ""
 
-#: src/tilda.ui:206
+#: src/tilda.ui:223
 msgid "White on Black"
 msgstr ""
 
-#: src/tilda.ui:209 src/wizard.c:223
+#: src/tilda.ui:226 src/wizard.c:223
 msgid "Zenburn"
 msgstr ""
 
-#: src/tilda.ui:212 src/wizard.c:224
+#: src/tilda.ui:229 src/wizard.c:224
 msgid "Solarized Light"
 msgstr ""
 
-#: src/tilda.ui:215 src/wizard.c:225
+#: src/tilda.ui:232 src/wizard.c:225
 msgid "Solarized Dark"
 msgstr ""
 
-#: src/tilda.ui:218 src/wizard.c:226
+#: src/tilda.ui:235 src/wizard.c:226
 msgid "Snazzy"
 msgstr ""
 
-#: src/tilda.ui:240
+#: src/tilda.ui:257
 msgid "On the Left"
 msgstr ""
 
-#: src/tilda.ui:243
+#: src/tilda.ui:260
 msgid "On the Right"
 msgstr ""
 
-#: src/tilda.ui:246
+#: src/tilda.ui:263
 msgid "Disabled"
 msgstr ""
 
-#: src/tilda.ui:257 src/tilda.ui:274
+#: src/tilda.ui:274 src/tilda.ui:291
 msgid "ASCII DEL"
 msgstr ""
 
-#: src/tilda.ui:260 src/tilda.ui:277
+#: src/tilda.ui:277 src/tilda.ui:294
 #, fuzzy
 msgid "Escape sequence"
 msgstr ""
@@ -158,27 +202,15 @@ msgstr ""
 "Управляющую последовательность\n"
 "Control-H"
 
-#: src/tilda.ui:263 src/tilda.ui:280
+#: src/tilda.ui:280 src/tilda.ui:297
 msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
-msgid "Show whole tab title"
-msgstr ""
-
-#: src/tilda.ui:294
-msgid "Show first n chars of title"
-msgstr ""
-
-#: src/tilda.ui:297
-msgid "Show last n chars of title"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr "Настройка Tilda"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Скрыть Tilda при запуске"
 
@@ -210,141 +242,137 @@ msgstr ""
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>Настройки отображения</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr "Мерцающий курсор"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr "Звуковой терминальный сигнал"
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Внешний вид терминала</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "Включить сглаживание"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "Разрешить полужирный текст"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "Шрифт:"
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Шрифт</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr ""
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr ""
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr ""
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 #, fuzzy
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Заголовок</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Поверх всех окон"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 #, fuzzy
 msgid "<b>Program Exit</b>"
 msgstr "<b>Расположение</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "Основные"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr ""
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr ""
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 #, fuzzy
 msgid "Web Browser *:"
 msgstr "Веб-браузер"
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr "<b>Обработка URL</b>"
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Исходный заголовок:"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Автоматически установленный заголовок"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Заголовок</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr "Запускать пользовательскую команду вместо shell"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "Пользовательская команда:"
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr "Когда команда завершается:"
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Команда</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -352,264 +380,256 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 #, fuzzy
 msgid "Close Action"
 msgstr "_Закрыть вкладку"
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Заголовок и команда"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "В процентах:"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "В пикселах:"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Высота</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 #, fuzzy
 msgid "<b>Select monitor</b>"
 msgstr "<b>Заголовок</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Ширина</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Центрировать по горизонтали"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Позиция по вертикали"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "Позиция по горизонтали"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Центрировать по вертикали"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Расположение</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr "Расположение закладок:"
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Заголовок</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Продолжительность анимации (мкс)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Направление анимации"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Использовать изображение в качестве фона"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Анимировать появление/скрытие"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Уровень прозрачности"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Включить прозрачность"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Дополнительно</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Внешний вид"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 #, fuzzy
 msgid "Cursor Color"
 msgstr "Мерцающий курсор"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "Цвет текста"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "Цвет фона"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr "Встроенные схемы"
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr "<b>Цвет текста и фона</b>"
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 #, fuzzy
 msgid "Built-in schemes:"
 msgstr "Встроенные схемы"
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr ""
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 #, fuzzy
 msgid "<b>Palette</b>"
 msgstr "<b>Заголовок</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Цвета"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "Полоса прокрутки:"
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 #, fuzzy
 msgid "Limit scrollback to:"
 msgstr "Буфер прокрутки:"
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "Прокручивать по мере появления текста"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr "Прокручивать клавишами"
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "Прокручивать фоновое изображение"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "cтрок(и)"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>Прокрутка</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Прокрутка"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -621,53 +641,53 @@ msgstr ""
 "работать с некоторыми приложениями и операционными ситемами, ожидающими "
 "другого поведения терминала.</i></small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr "Клавиша _Backspace вызывает:"
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr "Клавиша _Delete вызывает:"
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Восстановить параметры совместимости по умолчанию"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>Совместимость</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Совместимость"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "Сочетание клавиш"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "Сочетание клавиш"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -689,61 +709,53 @@ msgstr "Возникла ошибка при записи конфигураци
 msgid "Unable to run command: `%s'\n"
 msgstr "Не удалось выполнить команду: «%s»\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr "Невозможно открыть директорию lock: %s\n"
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "Использовать сглаживание шрифтов"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Установить цвет фона"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Запустить команду при запуске"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Использовать указанный шрифт"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Запустить мастер конфигурации"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "Размер буфера прокрутки, строк"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "Использовать полосу прокрутки"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Вывести версию и выйти"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "Установить рабочую директорию"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Установить фоновое изображение"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "Непрозрачность: 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "Запустить мастер конфигурации"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -756,7 +768,7 @@ msgstr ""
 "\n"
 "Сообщение об ошибке: %s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, fuzzy, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -770,70 +782,88 @@ msgstr ""
 "\n"
 "Сообщение об ошибке: %s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 #, fuzzy
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
 msgstr "Комбинация клавиш, которую вы выбрали, неверная. Выберите другую."
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+#, fuzzy
+msgid "Action"
+msgstr "_Закрыть вкладку"
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, fuzzy, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr "Комбинация клавиш, которую вы выбрали, неверная. Выберите другую."
+
+#: src/tilda_terminal.c:397
 #, fuzzy, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr "Возникла проблема при обработке пользовательской команды: %s\n"
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr "Возникла проблема при обработке пользовательской команды: %s\n"
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr "Запуск оболочки по умолчанию вместо\n"
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr "Не удалось запустить пользовательскую команду: %s\n"
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr "Не удалось запустить оболочку по умолчанию: %s\n"
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr "Ошибка при запуске веб-браузера командой «%s»\n"
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "Безымянный"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr "Неправильное значение параметра \"d_set_title\" в файле конфигурации\n"
 
@@ -845,16 +875,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr "Неправильный параметр tab_pos в файле конфигурации\n"
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "Не удалось установить иконку tilda: %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "Не удалось создать вкладку: память исчерпана\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -874,22 +904,37 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, fuzzy, c-format
 msgid "Tilda %d Config"
 msgstr "Настройка Tilda"
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr "Неправильный вариант положения вкладки, пропущен\n"
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "Включить сглаживание"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Использовать изображение в качестве фона"
+
+#~ msgid "Scroll Background"
+#~ msgstr "Прокручивать фоновое изображение"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "Использовать сглаживание шрифтов"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Установить фоновое изображение"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Двойная буферизация"
@@ -928,12 +973,6 @@ msgstr "Неправильный вариант положения вкладк�
 #, fuzzy
 #~ msgid "Problem when opening config file\n"
 #~ msgstr "Возникла проблема при обработке файла конфигурации\n"
-
-#~ msgid "_New Tab"
-#~ msgstr "_Новая вкладка"
-
-#~ msgid "_Close Tab"
-#~ msgstr "_Закрыть вкладку"
 
 #, fuzzy
 #~ msgid ""
@@ -974,11 +1013,6 @@ msgstr "Неправильный вариант положения вкладк�
 #, fuzzy
 #~ msgid ""
 #~ "The keybinding you chose for \"Copy\" is invalid. Please choose another."
-#~ msgstr "Комбинация клавиш, которую вы выбрали, неверная. Выберите другую."
-
-#, fuzzy
-#~ msgid ""
-#~ "The keybinding you chose for \"Paste\" is invalid. Please choose another."
 #~ msgstr "Комбинация клавиш, которую вы выбрали, неверная. Выберите другую."
 
 #, fuzzy

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2007-11-22 22:15+0000\n"
 "Last-Translator: Matej Duman <matejduman@gmail.com>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -17,6 +17,39 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr ""
+
+#: src/menu.ui:10
+#, fuzzy
+msgid "_Close Tab"
+msgstr "<b>Príkaz</b>"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 msgid "Close Tilda"
@@ -30,19 +63,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -71,107 +104,107 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
+msgid "Show whole tab title"
 msgstr ""
 
 #: src/tilda.ui:143
-msgid "Goes after initial title"
+msgid "Show first n chars of title"
 msgstr ""
 
 #: src/tilda.ui:146
+msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
 msgid "Goes before initial title"
 msgstr ""
 
-#: src/tilda.ui:149
+#: src/tilda.ui:166
 #, fuzzy
 msgid "Replace initial title"
 msgstr "Počiatočný titulok:"
 
-#: src/tilda.ui:160
+#: src/tilda.ui:177
 msgid "Drop to the default shell"
 msgstr ""
 
-#: src/tilda.ui:163
+#: src/tilda.ui:180
 msgid "Restart the command"
 msgstr ""
 
-#: src/tilda.ui:166
+#: src/tilda.ui:183
 msgid "Exit the terminal"
 msgstr ""
 
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
 msgid "Custom"
 msgstr ""
 
-#: src/tilda.ui:200
+#: src/tilda.ui:217
 msgid "Green on Black"
 msgstr ""
 
-#: src/tilda.ui:203
+#: src/tilda.ui:220
 msgid "Black on White"
 msgstr ""
 
-#: src/tilda.ui:206
+#: src/tilda.ui:223
 msgid "White on Black"
 msgstr ""
 
-#: src/tilda.ui:209 src/wizard.c:223
+#: src/tilda.ui:226 src/wizard.c:223
 msgid "Zenburn"
 msgstr ""
 
-#: src/tilda.ui:212 src/wizard.c:224
+#: src/tilda.ui:229 src/wizard.c:224
 msgid "Solarized Light"
 msgstr ""
 
-#: src/tilda.ui:215 src/wizard.c:225
+#: src/tilda.ui:232 src/wizard.c:225
 msgid "Solarized Dark"
 msgstr ""
 
-#: src/tilda.ui:218 src/wizard.c:226
+#: src/tilda.ui:235 src/wizard.c:226
 msgid "Snazzy"
 msgstr ""
 
-#: src/tilda.ui:240
+#: src/tilda.ui:257
 msgid "On the Left"
 msgstr ""
 
-#: src/tilda.ui:243
+#: src/tilda.ui:260
 msgid "On the Right"
 msgstr ""
 
-#: src/tilda.ui:246
+#: src/tilda.ui:263
 msgid "Disabled"
 msgstr ""
 
-#: src/tilda.ui:257 src/tilda.ui:274
+#: src/tilda.ui:274 src/tilda.ui:291
 msgid "ASCII DEL"
 msgstr ""
 
-#: src/tilda.ui:260 src/tilda.ui:277
+#: src/tilda.ui:277 src/tilda.ui:294
 msgid "Escape sequence"
 msgstr ""
 
-#: src/tilda.ui:263 src/tilda.ui:280
+#: src/tilda.ui:280 src/tilda.ui:297
 msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
-msgid "Show whole tab title"
-msgstr ""
-
-#: src/tilda.ui:294
-msgid "Show first n chars of title"
-msgstr ""
-
-#: src/tilda.ui:297
-msgid "Show last n chars of title"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr ""
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Spustiť Tildu skrytú"
 
@@ -203,140 +236,136 @@ msgstr ""
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>Zobrazenie okna</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr ""
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr ""
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Zobrazenie terminálu</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr ""
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr ""
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr ""
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Písmo</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr ""
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr ""
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr ""
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 #, fuzzy
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Titulok</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Vždy navrchu"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 #, fuzzy
 msgid "<b>Program Exit</b>"
 msgstr "<b>Umiestnenie</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "Všeobecné"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr ""
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr ""
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 msgid "Web Browser *:"
 msgstr ""
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr ""
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Počiatočný titulok:"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Dynamický titulok:"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Titulok</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr ""
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr ""
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr ""
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Príkaz</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -344,261 +373,253 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 msgid "Close Action"
 msgstr ""
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Titulok a príkaz"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Percentuálne vyjadrenie"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "V pixeloch"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Výška</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 #, fuzzy
 msgid "<b>Select monitor</b>"
 msgstr "<b>Titulok</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Šírka</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Zarovnať vodorovne"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Pozícia Y"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "Pozícia X"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Zarovnať zvislo"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Umiestnenie</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr ""
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Titulok</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Dĺžka animácie (mikrosekundy)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Začiatok animácie"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Použiť obrázok ako pozadie"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Animované vysunutie"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Úroveň priehľadnosti"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Povoliť priehľadnosť"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Doplnky</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Vzhľad"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 msgid "Cursor Color"
 msgstr ""
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr ""
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr ""
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr ""
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr ""
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 msgid "Built-in schemes:"
 msgstr ""
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr ""
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 #, fuzzy
 msgid "<b>Palette</b>"
 msgstr "<b>Titulok</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Farby"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "Posúvač je:"
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 #, fuzzy
 msgid "Limit scrollback to:"
 msgstr "História"
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "Posúvať pri výstupe"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr ""
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "Posúvať pozadie"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr ""
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr ""
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Posúvanie"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -606,53 +627,53 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr ""
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr ""
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Kompatibilita"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "Klávesové skratky"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "Klávesové skratky"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -674,61 +695,53 @@ msgstr "Nemôžem zapísať konfiguračný súbor do %s\n"
 msgid "Unable to run command: `%s'\n"
 msgstr ""
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr ""
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "Použiť vyhladzovanie písma"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Nastaviť farbu pozadia"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Spustiť pri štarte príkaz"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Nastaviť písmo pre nasledujúci reťazec"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Zobraziť sprievodcu konfiguráciou"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "História riadkov"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "Použiť posúvač"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Napísať číslo verzie a potom skončiť"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "Nastaviť počiatočný pracovný priečinok"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Nastaviť obrázok pozadia"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "Priehľadnosť: 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "Zobraziť sprievodcu konfiguráciou"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -741,7 +754,7 @@ msgstr ""
 "\n"
 "Chybové hlásenie: %s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, fuzzy, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -755,69 +768,86 @@ msgstr ""
 "\n"
 "Chybové hlásenie: %s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
 msgstr ""
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+msgid "Action"
+msgstr ""
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+
+#: src/tilda_terminal.c:397
 #, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr ""
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr ""
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr ""
 
@@ -829,16 +859,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr ""
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "Nemôžem nastaviť ikonu tildy: %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "Nedostatok pamäte, nemôžem vytvoriť kartu\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -858,22 +888,34 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, c-format
 msgid "Tilda %d Config"
 msgstr ""
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr ""
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Použiť obrázok ako pozadie"
+
+#~ msgid "Scroll Background"
+#~ msgstr "Posúvať pozadie"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "Použiť vyhladzovanie písma"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Nastaviť obrázok pozadia"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Povoliť dvojitý buffering"
@@ -885,10 +927,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "<b>Quit</b>"
 #~ msgstr "<b>Titulok</b>"
-
-#, fuzzy
-#~ msgid "<b>Close Tab</b>"
-#~ msgstr "<b>Príkaz</b>"
 
 #, fuzzy
 #~ msgid "<b>Copy</b>"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2007-07-11 00:16+0000\n"
 "Last-Translator: Nejc Lotrič <Unknown>\n"
 "Language-Team: Slovenian <sl@li.org>\n"
@@ -17,6 +17,39 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr ""
+
+#: src/menu.ui:10
+#, fuzzy
+msgid "_Close Tab"
+msgstr "<b>Ukaz</b>"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 msgid "Close Tilda"
@@ -30,19 +63,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -71,107 +104,107 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
+msgid "Show whole tab title"
 msgstr ""
 
 #: src/tilda.ui:143
-msgid "Goes after initial title"
+msgid "Show first n chars of title"
 msgstr ""
 
 #: src/tilda.ui:146
+msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
 msgid "Goes before initial title"
 msgstr ""
 
-#: src/tilda.ui:149
+#: src/tilda.ui:166
 #, fuzzy
 msgid "Replace initial title"
 msgstr "Prvotni Naslov:"
 
-#: src/tilda.ui:160
+#: src/tilda.ui:177
 msgid "Drop to the default shell"
 msgstr ""
 
-#: src/tilda.ui:163
+#: src/tilda.ui:180
 msgid "Restart the command"
 msgstr ""
 
-#: src/tilda.ui:166
+#: src/tilda.ui:183
 msgid "Exit the terminal"
 msgstr ""
 
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
 msgid "Custom"
 msgstr ""
 
-#: src/tilda.ui:200
+#: src/tilda.ui:217
 msgid "Green on Black"
 msgstr ""
 
-#: src/tilda.ui:203
+#: src/tilda.ui:220
 msgid "Black on White"
 msgstr ""
 
-#: src/tilda.ui:206
+#: src/tilda.ui:223
 msgid "White on Black"
 msgstr ""
 
-#: src/tilda.ui:209 src/wizard.c:223
+#: src/tilda.ui:226 src/wizard.c:223
 msgid "Zenburn"
 msgstr ""
 
-#: src/tilda.ui:212 src/wizard.c:224
+#: src/tilda.ui:229 src/wizard.c:224
 msgid "Solarized Light"
 msgstr ""
 
-#: src/tilda.ui:215 src/wizard.c:225
+#: src/tilda.ui:232 src/wizard.c:225
 msgid "Solarized Dark"
 msgstr ""
 
-#: src/tilda.ui:218 src/wizard.c:226
+#: src/tilda.ui:235 src/wizard.c:226
 msgid "Snazzy"
 msgstr ""
 
-#: src/tilda.ui:240
+#: src/tilda.ui:257
 msgid "On the Left"
 msgstr ""
 
-#: src/tilda.ui:243
+#: src/tilda.ui:260
 msgid "On the Right"
 msgstr ""
 
-#: src/tilda.ui:246
+#: src/tilda.ui:263
 msgid "Disabled"
 msgstr ""
 
-#: src/tilda.ui:257 src/tilda.ui:274
+#: src/tilda.ui:274 src/tilda.ui:291
 msgid "ASCII DEL"
 msgstr ""
 
-#: src/tilda.ui:260 src/tilda.ui:277
+#: src/tilda.ui:277 src/tilda.ui:294
 msgid "Escape sequence"
 msgstr ""
 
-#: src/tilda.ui:263 src/tilda.ui:280
+#: src/tilda.ui:280 src/tilda.ui:297
 msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
-msgid "Show whole tab title"
-msgstr ""
-
-#: src/tilda.ui:294
-msgid "Show first n chars of title"
-msgstr ""
-
-#: src/tilda.ui:297
-msgid "Show last n chars of title"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr ""
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr ""
 
@@ -203,140 +236,136 @@ msgstr ""
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>Okenski prikaz</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr ""
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr ""
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Prikaz v Terminalu</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr ""
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr ""
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr ""
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Pisava</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr ""
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr ""
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr ""
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 #, fuzzy
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Naslov</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Vedno na vrhu"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 #, fuzzy
 msgid "<b>Program Exit</b>"
 msgstr "<b>Pozicija</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "Splošno"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr ""
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr ""
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 msgid "Web Browser *:"
 msgstr ""
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr ""
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Prvotni Naslov:"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr ""
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Naslov</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr ""
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr ""
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr ""
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Ukaz</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -344,261 +373,253 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 msgid "Close Action"
 msgstr ""
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Naslov in Ukaz"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Odstotek"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "V Pikslih"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Višina</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 #, fuzzy
 msgid "<b>Select monitor</b>"
 msgstr "<b>Naslov</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Širina</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr ""
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Pozicija Y"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "Pozicija X"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr ""
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 #, fuzzy
 msgid "<b>Position</b>"
 msgstr "<b>Pozicija</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr ""
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Naslov</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Zakasnitev Animacij (usec)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr ""
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Uporabi Sliko za Ozadje"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr ""
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Nivo Prozornosti"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Vključi Prosojnost"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Dodatki</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Videz"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 msgid "Cursor Color"
 msgstr ""
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr ""
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr ""
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr ""
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr ""
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 msgid "Built-in schemes:"
 msgstr ""
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr ""
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 #, fuzzy
 msgid "<b>Palette</b>"
 msgstr "<b>Naslov</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Barve"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr ""
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 msgid "Limit scrollback to:"
 msgstr ""
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr ""
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr ""
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr ""
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr ""
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr ""
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Premikanje zaslona"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -606,53 +627,53 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr ""
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr ""
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Združljivost"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "<b>Višina</b>"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr ""
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -674,61 +695,53 @@ msgstr ""
 msgid "Unable to run command: `%s'\n"
 msgstr ""
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr ""
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr ""
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Nastavi barvo ozadja"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Poženi ukaz ob zagonu"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr ""
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Prikaži Čarovnika Nastavitev"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr ""
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr ""
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr ""
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr ""
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Nastavi Sliko Ozadja"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr ""
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "Prikaži Čarovnika Nastavitev"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -737,7 +750,7 @@ msgid ""
 "Error message: %s\n"
 msgstr ""
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -747,69 +760,86 @@ msgid ""
 "Error message: %s\n"
 msgstr ""
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
 msgstr ""
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+msgid "Action"
+msgstr ""
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+
+#: src/tilda_terminal.c:397
 #, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr ""
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr ""
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr ""
 
@@ -821,16 +851,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr ""
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "Ni moč nastaviti ikone tilde: %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr ""
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -850,22 +880,28 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, c-format
 msgid "Tilda %d Config"
 msgstr ""
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr ""
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Uporabi Sliko za Ozadje"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Nastavi Sliko Ozadja"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Omogoči Dvojno Medpomnenje"
@@ -877,10 +913,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "<b>Quit</b>"
 #~ msgstr "<b>Naslov</b>"
-
-#, fuzzy
-#~ msgid "<b>Close Tab</b>"
-#~ msgstr "<b>Ukaz</b>"
 
 #, fuzzy
 #~ msgid "<b>Copy</b>"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2007-05-14 18:18+0000\n"
 "Last-Translator: Umut <Unknown>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -17,6 +17,39 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr ""
+
+#: src/menu.ui:10
+#, fuzzy
+msgid "_Close Tab"
+msgstr "<b>Kommando</b>"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 msgid "Close Tilda"
@@ -30,19 +63,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -71,107 +104,107 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
+msgid "Show whole tab title"
 msgstr ""
 
 #: src/tilda.ui:143
-msgid "Goes after initial title"
+msgid "Show first n chars of title"
 msgstr ""
 
 #: src/tilda.ui:146
+msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
 msgid "Goes before initial title"
 msgstr ""
 
-#: src/tilda.ui:149
+#: src/tilda.ui:166
 #, fuzzy
 msgid "Replace initial title"
 msgstr "Initial titel:"
 
-#: src/tilda.ui:160
+#: src/tilda.ui:177
 msgid "Drop to the default shell"
 msgstr ""
 
-#: src/tilda.ui:163
+#: src/tilda.ui:180
 msgid "Restart the command"
 msgstr ""
 
-#: src/tilda.ui:166
+#: src/tilda.ui:183
 msgid "Exit the terminal"
 msgstr ""
 
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
 msgid "Custom"
 msgstr ""
 
-#: src/tilda.ui:200
+#: src/tilda.ui:217
 msgid "Green on Black"
 msgstr ""
 
-#: src/tilda.ui:203
+#: src/tilda.ui:220
 msgid "Black on White"
 msgstr ""
 
-#: src/tilda.ui:206
+#: src/tilda.ui:223
 msgid "White on Black"
 msgstr ""
 
-#: src/tilda.ui:209 src/wizard.c:223
+#: src/tilda.ui:226 src/wizard.c:223
 msgid "Zenburn"
 msgstr ""
 
-#: src/tilda.ui:212 src/wizard.c:224
+#: src/tilda.ui:229 src/wizard.c:224
 msgid "Solarized Light"
 msgstr ""
 
-#: src/tilda.ui:215 src/wizard.c:225
+#: src/tilda.ui:232 src/wizard.c:225
 msgid "Solarized Dark"
 msgstr ""
 
-#: src/tilda.ui:218 src/wizard.c:226
+#: src/tilda.ui:235 src/wizard.c:226
 msgid "Snazzy"
 msgstr ""
 
-#: src/tilda.ui:240
+#: src/tilda.ui:257
 msgid "On the Left"
 msgstr ""
 
-#: src/tilda.ui:243
+#: src/tilda.ui:260
 msgid "On the Right"
 msgstr ""
 
-#: src/tilda.ui:246
+#: src/tilda.ui:263
 msgid "Disabled"
 msgstr ""
 
-#: src/tilda.ui:257 src/tilda.ui:274
+#: src/tilda.ui:274 src/tilda.ui:291
 msgid "ASCII DEL"
 msgstr ""
 
-#: src/tilda.ui:260 src/tilda.ui:277
+#: src/tilda.ui:277 src/tilda.ui:294
 msgid "Escape sequence"
 msgstr ""
 
-#: src/tilda.ui:263 src/tilda.ui:280
+#: src/tilda.ui:280 src/tilda.ui:297
 msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
-msgid "Show whole tab title"
-msgstr ""
-
-#: src/tilda.ui:294
-msgid "Show first n chars of title"
-msgstr ""
-
-#: src/tilda.ui:297
-msgid "Show last n chars of title"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr ""
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Starta Tilda dold"
 
@@ -203,140 +236,136 @@ msgstr ""
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>Fönstervisning</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr ""
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr ""
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>Terminalvisning</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr ""
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr ""
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr ""
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>Typsnitt</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr ""
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr ""
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr ""
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 #, fuzzy
 msgid "<b>Auto Hide</b>"
 msgstr "<b>Titel</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "Alltid överst"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 #, fuzzy
 msgid "<b>Program Exit</b>"
 msgstr "<b>Position</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "Allmänt"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr ""
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr ""
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 msgid "Web Browser *:"
 msgstr ""
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr ""
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "Initial titel:"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "Dynamiskt inställd titel:"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>Titel</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr ""
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr ""
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr ""
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>Kommando</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -344,261 +373,253 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 msgid "Close Action"
 msgstr ""
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "Titel och kommando"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "Procentandel"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "I bildpunkter"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>Höjd</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 #, fuzzy
 msgid "<b>Select monitor</b>"
 msgstr "<b>Titel</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>Bredd</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "Horisontellt centrerad"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Y-position"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "X-position"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "Vertikalt centrerad"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>Position</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr ""
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>Titel</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "Fördröjning för animering (ms)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "Orientering för animering"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "Använd bild som bakgrund"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "Animerad rullgardin"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "Nivå av genomskinlighet"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "Aktivera genomskinlighet"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>Extrafunktioner</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "Utseende"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 msgid "Cursor Color"
 msgstr ""
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr ""
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr ""
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr ""
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr ""
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 msgid "Built-in schemes:"
 msgstr ""
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr ""
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 #, fuzzy
 msgid "<b>Palette</b>"
 msgstr "<b>Titel</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "Färger"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "Rullningslisten är:"
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 #, fuzzy
 msgid "Limit scrollback to:"
 msgstr "Rullningslängd:"
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "Rulla vid utmatning"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr ""
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "Rulla bakgrunden"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr ""
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr ""
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "Rullning"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -606,53 +627,53 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr ""
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr ""
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "Kompatibilitet"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 #, fuzzy
 msgid "<b>Keybindings</b>"
 msgstr "Tangentbindningar"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "Tangentbindningar"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -674,61 +695,53 @@ msgstr "Kunde inte skriva konfigurationsfilen till %s\n"
 msgid "Unable to run command: `%s'\n"
 msgstr ""
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr ""
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "Använd kantutjämnade typsnitt"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "Ställ in bakgrundsfärgen"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "Kör ett kommando vid uppstart"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "Ställ in typsnittet till följande sträng"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 #, fuzzy
 msgid "Configuration file"
 msgstr "Visa konfigurationsguide"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "Antal rader att rulla tillbaka"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "Använd rullningslist"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "Skriv ut versionen, avsluta sedan"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "Ställ in initial arbetskatalog"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "Ställ in bakgrundsbild"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "Opakhet: 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "Visa konfigurationsguide"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -741,7 +754,7 @@ msgstr ""
 "\n"
 "Felmeddelande: %s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, fuzzy, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -755,69 +768,86 @@ msgstr ""
 "\n"
 "Felmeddelande: %s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
 msgstr ""
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+msgid "Action"
+msgstr ""
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+
+#: src/tilda_terminal.c:397
 #, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr ""
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr ""
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr ""
 
@@ -829,16 +859,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr ""
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "Kunde inte ställa in ikon för tilda: %s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "Slut på minne, kan inte skapa flik\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -858,22 +888,34 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, c-format
 msgid "Tilda %d Config"
 msgstr ""
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr ""
+
+#~ msgid "Use Image for Background"
+#~ msgstr "Använd bild som bakgrund"
+
+#~ msgid "Scroll Background"
+#~ msgstr "Rulla bakgrunden"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "Använd kantutjämnade typsnitt"
+
+#~ msgid "Set Background Image"
+#~ msgstr "Ställ in bakgrundsbild"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "Aktivera dubbelbuffring"
@@ -885,10 +927,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "<b>Quit</b>"
 #~ msgstr "<b>Titel</b>"
-
-#, fuzzy
-#~ msgid "<b>Close Tab</b>"
-#~ msgstr "<b>Kommando</b>"
 
 #, fuzzy
 #~ msgid "<b>Copy</b>"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2007-05-22 18:11+0000\n"
 "Last-Translator: Alperen Yusuf Aybar <alperen@aybar.biz>\n"
 "Language-Team: Turkish <tr@li.org>\n"
@@ -17,6 +17,38 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr ""
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr ""
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 msgid "Close Tilda"
@@ -30,19 +62,19 @@ msgstr ""
 msgid "Open a new terminal and hide"
 msgstr ""
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr ""
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr ""
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr ""
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr ""
 
@@ -71,106 +103,106 @@ msgid "Underline Cursor"
 msgstr ""
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
-msgstr ""
-
-#: src/tilda.ui:143
-msgid "Goes after initial title"
-msgstr ""
-
-#: src/tilda.ui:146
-msgid "Goes before initial title"
-msgstr ""
-
-#: src/tilda.ui:149
-msgid "Replace initial title"
-msgstr ""
-
-#: src/tilda.ui:160
-msgid "Drop to the default shell"
-msgstr ""
-
-#: src/tilda.ui:163
-msgid "Restart the command"
-msgstr ""
-
-#: src/tilda.ui:166
-msgid "Exit the terminal"
-msgstr ""
-
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
-msgid "Custom"
-msgstr ""
-
-#: src/tilda.ui:200
-msgid "Green on Black"
-msgstr ""
-
-#: src/tilda.ui:203
-msgid "Black on White"
-msgstr ""
-
-#: src/tilda.ui:206
-msgid "White on Black"
-msgstr ""
-
-#: src/tilda.ui:209 src/wizard.c:223
-msgid "Zenburn"
-msgstr ""
-
-#: src/tilda.ui:212 src/wizard.c:224
-msgid "Solarized Light"
-msgstr ""
-
-#: src/tilda.ui:215 src/wizard.c:225
-msgid "Solarized Dark"
-msgstr ""
-
-#: src/tilda.ui:218 src/wizard.c:226
-msgid "Snazzy"
-msgstr ""
-
-#: src/tilda.ui:240
-msgid "On the Left"
-msgstr ""
-
-#: src/tilda.ui:243
-msgid "On the Right"
-msgstr ""
-
-#: src/tilda.ui:246
-msgid "Disabled"
-msgstr ""
-
-#: src/tilda.ui:257 src/tilda.ui:274
-msgid "ASCII DEL"
-msgstr ""
-
-#: src/tilda.ui:260 src/tilda.ui:277
-msgid "Escape sequence"
-msgstr ""
-
-#: src/tilda.ui:263 src/tilda.ui:280
-msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
 msgid "Show whole tab title"
 msgstr ""
 
-#: src/tilda.ui:294
+#: src/tilda.ui:143
 msgid "Show first n chars of title"
 msgstr ""
 
-#: src/tilda.ui:297
+#: src/tilda.ui:146
 msgid "Show last n chars of title"
+msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr ""
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr ""
+
+#: src/tilda.ui:163
+msgid "Goes before initial title"
+msgstr ""
+
+#: src/tilda.ui:166
+msgid "Replace initial title"
+msgstr ""
+
+#: src/tilda.ui:177
+msgid "Drop to the default shell"
+msgstr ""
+
+#: src/tilda.ui:180
+msgid "Restart the command"
+msgstr ""
+
+#: src/tilda.ui:183
+msgid "Exit the terminal"
+msgstr ""
+
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
+msgid "Custom"
+msgstr ""
+
+#: src/tilda.ui:217
+msgid "Green on Black"
+msgstr ""
+
+#: src/tilda.ui:220
+msgid "Black on White"
+msgstr ""
+
+#: src/tilda.ui:223
+msgid "White on Black"
+msgstr ""
+
+#: src/tilda.ui:226 src/wizard.c:223
+msgid "Zenburn"
+msgstr ""
+
+#: src/tilda.ui:229 src/wizard.c:224
+msgid "Solarized Light"
+msgstr ""
+
+#: src/tilda.ui:232 src/wizard.c:225
+msgid "Solarized Dark"
+msgstr ""
+
+#: src/tilda.ui:235 src/wizard.c:226
+msgid "Snazzy"
+msgstr ""
+
+#: src/tilda.ui:257
+msgid "On the Left"
+msgstr ""
+
+#: src/tilda.ui:260
+msgid "On the Right"
+msgstr ""
+
+#: src/tilda.ui:263
+msgid "Disabled"
+msgstr ""
+
+#: src/tilda.ui:274 src/tilda.ui:291
+msgid "ASCII DEL"
+msgstr ""
+
+#: src/tilda.ui:277 src/tilda.ui:294
+msgid "Escape sequence"
+msgstr ""
+
+#: src/tilda.ui:280 src/tilda.ui:297
+msgid "Control-H"
 msgstr ""
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr ""
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr ""
 
@@ -202,137 +234,133 @@ msgstr ""
 msgid "Non-focus Pull Up Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr ""
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr ""
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr ""
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr ""
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr ""
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr ""
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr ""
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr ""
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr ""
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr ""
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr ""
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr ""
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 msgid "<b>Auto Hide</b>"
 msgstr ""
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr ""
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 msgid "Always prompt on exit"
 msgstr ""
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 msgid "<b>Program Exit</b>"
 msgstr ""
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr ""
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr ""
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr ""
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 msgid "Web Browser *:"
 msgstr ""
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr ""
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr ""
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr ""
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr ""
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr ""
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr ""
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr ""
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr ""
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr ""
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -340,257 +368,249 @@ msgid ""
 "best command may be different depending on the system."
 msgstr ""
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 msgid "Close Action"
 msgstr ""
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr ""
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr ""
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr ""
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr ""
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr ""
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 msgid "<b>Select monitor</b>"
 msgstr ""
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr ""
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr ""
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr ""
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr ""
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr ""
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr ""
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr ""
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 msgid "<b>Tabs</b>"
 msgstr ""
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr ""
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr ""
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr ""
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr ""
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr ""
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr ""
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr ""
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr ""
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 msgid "Cursor Color"
 msgstr ""
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr ""
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr ""
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr ""
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr ""
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr ""
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr ""
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr ""
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr ""
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr ""
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr ""
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr ""
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr ""
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr ""
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr ""
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr ""
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr ""
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr ""
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr ""
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr ""
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr ""
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 msgid "Built-in schemes:"
 msgstr ""
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr ""
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr ""
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr ""
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 msgid "Limit scrollback to:"
 msgstr ""
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr ""
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr ""
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr ""
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr ""
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr ""
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr ""
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr ""
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr ""
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -598,52 +618,52 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr ""
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr ""
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr ""
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 msgid "<b>Keybindings</b>"
 msgstr ""
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr ""
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr ""
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr ""
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr ""
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr ""
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr ""
 
@@ -665,60 +685,52 @@ msgstr ""
 msgid "Unable to run command: `%s'\n"
 msgstr ""
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr ""
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr ""
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr ""
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr ""
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr ""
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 msgid "Configuration file"
 msgstr ""
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr ""
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr ""
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr ""
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr ""
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr ""
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr ""
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr ""
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -727,7 +739,7 @@ msgid ""
 "Error message: %s\n"
 msgstr ""
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -737,69 +749,86 @@ msgid ""
 "Error message: %s\n"
 msgstr ""
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr ""
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr ""
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr ""
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr ""
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr ""
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
 msgstr ""
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+msgid "Action"
+msgstr ""
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr ""
+
+#: src/tilda_terminal.c:397
 #, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr ""
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr ""
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr ""
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr ""
 
@@ -811,16 +840,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr ""
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr ""
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr ""
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -840,19 +869,19 @@ msgstr ""
 msgid "Rxvt"
 msgstr ""
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, c-format
 msgid "Tilda %d Config"
 msgstr ""
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr ""
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr ""
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,184 +1,208 @@
 # Chinese (China) translation for tilda
 # Copyright (c) 2007 Rosetta Contributors and Canonical Ltd 2007
 # This file is distributed under the same license as the tilda package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007.
+# Boyuan Yang <073plan@gmail.com>, 2018.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
-"PO-Revision-Date: 2008-03-17 23:34+0000\n"
-"Last-Translator: luojie-dune <Unknown>\n"
-"Language-Team: Chinese (China) <zh_CN@li.org>\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
+"PO-Revision-Date: 2018-03-19 12:53+0800\n"
+"Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
+"Language-Team: Chinese (China) <i18n-zh@googlegroups.com>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2008-04-28 05:36+0000\n"
-"X-Generator: Launchpad (build Unknown)\n"
+"X-Generator: Poedit 2.0.6\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr "新建标签(_N)"
+
+#: src/menu.ui:10
+msgid "_Close Tab"
+msgstr "关闭标签(_C)"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr "复制(_C)"
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr "粘贴(_P)"
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr "切换全屏(_T)"
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr "切换搜索栏(_T)"
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr "首选项(_P)"
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr "退出(_Q)"
 
 #: src/tilda.ui:69
-#, fuzzy
 msgid "Close Tilda"
-msgstr "关闭标签(_C)"
+msgstr "关闭 Tilda"
 
 #: src/tilda.ui:72
 msgid "Open a new terminal"
-msgstr ""
+msgstr "打开新终端"
 
 #: src/tilda.ui:75
 msgid "Open a new terminal and hide"
-msgstr ""
+msgstr "打开新终端并隐藏"
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
-msgstr ""
+msgstr "顶部"
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
-msgstr ""
+msgstr "底部"
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
-msgstr ""
+msgstr "左侧"
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
-msgstr ""
+msgstr "右侧"
 
 #: src/tilda.ui:98
 msgid "Hidden"
-msgstr ""
+msgstr "隐藏的"
 
 #: src/tilda.ui:109
 msgid "Focus Terminal"
-msgstr ""
+msgstr "终端获得焦点"
 
 #: src/tilda.ui:112
-#, fuzzy
 msgid "Hide Terminal"
-msgstr "可闻的终端响铃"
+msgstr "隐藏终端"
 
 #: src/tilda.ui:123
 msgid "Block Cursor"
-msgstr ""
+msgstr "块状光标"
 
 #: src/tilda.ui:126
 msgid "IBeam Cursor"
-msgstr ""
+msgstr "IBeam 光标"
 
 #: src/tilda.ui:129
 msgid "Underline Cursor"
-msgstr ""
+msgstr "下划线光标"
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
-msgstr ""
+msgid "Show whole tab title"
+msgstr "显示整个标签页标题"
 
 #: src/tilda.ui:143
-msgid "Goes after initial title"
-msgstr ""
+msgid "Show first n chars of title"
+msgstr "显示标题最前 n 个字符"
 
 #: src/tilda.ui:146
-msgid "Goes before initial title"
-msgstr ""
+msgid "Show last n chars of title"
+msgstr "显示标题最后 n 个字符"
 
-#: src/tilda.ui:149
-#, fuzzy
-msgid "Replace initial title"
-msgstr "原始标题 :"
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr "未显示"
 
 #: src/tilda.ui:160
-#, fuzzy
-msgid "Drop to the default shell"
-msgstr "无法运行默认shell：%s\n"
+msgid "Goes after initial title"
+msgstr "在原始标题之后"
 
 #: src/tilda.ui:163
-msgid "Restart the command"
-msgstr ""
+msgid "Goes before initial title"
+msgstr "在原始标题之前"
 
 #: src/tilda.ui:166
+msgid "Replace initial title"
+msgstr "替代原始标题"
+
+#: src/tilda.ui:177
+msgid "Drop to the default shell"
+msgstr "回退到默认 shell"
+
+#: src/tilda.ui:180
+msgid "Restart the command"
+msgstr "重新启动命令"
+
+#: src/tilda.ui:183
 msgid "Exit the terminal"
-msgstr ""
+msgstr "退出终端"
 
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
 msgid "Custom"
-msgstr ""
+msgstr "自定义"
 
-#: src/tilda.ui:200
+#: src/tilda.ui:217
 msgid "Green on Black"
-msgstr ""
+msgstr "黑底绿字"
 
-#: src/tilda.ui:203
+#: src/tilda.ui:220
 msgid "Black on White"
-msgstr ""
+msgstr "白底黑字"
 
-#: src/tilda.ui:206
+#: src/tilda.ui:223
 msgid "White on Black"
-msgstr ""
+msgstr "黑底白字"
 
-#: src/tilda.ui:209 src/wizard.c:223
+#: src/tilda.ui:226 src/wizard.c:223
 msgid "Zenburn"
-msgstr ""
+msgstr "Zenburn"
 
-#: src/tilda.ui:212 src/wizard.c:224
+#: src/tilda.ui:229 src/wizard.c:224
 msgid "Solarized Light"
-msgstr ""
+msgstr "浅色的 Solarized"
 
-#: src/tilda.ui:215 src/wizard.c:225
+#: src/tilda.ui:232 src/wizard.c:225
 msgid "Solarized Dark"
-msgstr ""
+msgstr "深色的 Solarized"
 
-#: src/tilda.ui:218 src/wizard.c:226
+#: src/tilda.ui:235 src/wizard.c:226
 msgid "Snazzy"
-msgstr ""
+msgstr "Snazzy"
 
-#: src/tilda.ui:240
+#: src/tilda.ui:257
 msgid "On the Left"
-msgstr ""
+msgstr "左侧"
 
-#: src/tilda.ui:243
+#: src/tilda.ui:260
 msgid "On the Right"
-msgstr ""
+msgstr "右侧"
 
-#: src/tilda.ui:246
+#: src/tilda.ui:263
 msgid "Disabled"
-msgstr ""
+msgstr "禁用"
 
-#: src/tilda.ui:257 src/tilda.ui:274
+#: src/tilda.ui:274 src/tilda.ui:291
 msgid "ASCII DEL"
-msgstr ""
+msgstr "ASCII DEL"
 
-#: src/tilda.ui:260 src/tilda.ui:277
-#, fuzzy
+#: src/tilda.ui:277 src/tilda.ui:294
 msgid "Escape sequence"
-msgstr ""
-"ASCII DEL\n"
-"转码序列\n"
-"Ctrl+H"
+msgstr "转义序列"
 
-#: src/tilda.ui:263 src/tilda.ui:280
+#: src/tilda.ui:280 src/tilda.ui:297
 msgid "Control-H"
-msgstr ""
-
-#: src/tilda.ui:291
-msgid "Show whole tab title"
-msgstr ""
-
-#: src/tilda.ui:294
-msgid "Show first n chars of title"
-msgstr ""
-
-#: src/tilda.ui:297
-msgid "Show last n chars of title"
-msgstr ""
+msgstr "Control-H"
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
-msgstr "Tilda设置"
+msgstr "Tilda 配置"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "Tilda 启动后隐藏"
 
@@ -200,416 +224,398 @@ msgstr "显示窗口边框"
 
 #: src/tilda.ui:462
 msgid "Set as Desktop window"
-msgstr ""
+msgstr "设置为桌面窗口"
 
 #: src/tilda.ui:477
 msgid "Start in fullscreen"
-msgstr ""
+msgstr "启动时全屏"
 
 #: src/tilda.ui:506
 msgid "Non-focus Pull Up Behaviour:"
-msgstr ""
+msgstr "非焦点拉起行为："
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>窗口显示</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr "光标闪烁"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr "可闻的终端响铃"
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
-msgstr ""
+msgstr "光标形状："
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>终端显示</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "启用字体抗锯齿"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "允许粗体"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "字体："
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>字体</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
-msgstr ""
+msgstr "鼠标离开 Tilda 时隐藏"
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
-msgstr ""
+msgstr "自动隐藏延迟："
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
-msgstr ""
+msgstr "Tilda 失去焦点时隐藏"
 
-#: src/tilda.ui:851
-#, fuzzy
+#: src/tilda.ui:843
 msgid "<b>Auto Hide</b>"
-msgstr "<b>标题</b>"
+msgstr "<b>自动隐藏</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
-msgstr ""
+msgstr "最后一个终端关闭时："
 
-#: src/tilda.ui:917
-#, fuzzy
+#: src/tilda.ui:909
 msgid "Always prompt on exit"
-msgstr "置顶"
+msgstr "总是在退出时提示"
 
-#: src/tilda.ui:937
-#, fuzzy
+#: src/tilda.ui:932
 msgid "<b>Program Exit</b>"
-msgstr "<b>位置</b>"
+msgstr "<b>程序退出</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr ""
+"<small><i><b>注意：</b>某些选项修改后需重启 tilda 才能生效。</i></small>"
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "常规"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
-msgstr ""
+msgstr "文字字符范围："
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
-msgstr ""
+msgstr "<b>按文字选择</b>"
 
-#: src/tilda.ui:1095
-#, fuzzy
+#: src/tilda.ui:1090
 msgid "Web Browser *:"
-msgstr "网页浏览器"
+msgstr "网页浏览器*："
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr "<b>URL处理</b>"
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "原始标题 :"
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
-msgstr ""
+msgstr "标题最大长度："
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "动态设置标题:"
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
-msgstr ""
+msgstr "标题行为："
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>标题</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
-msgstr "运行一个自定义命令而非shell指令"
+msgstr "运行一个自定义命令而非 shell"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "自定义命令："
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
-msgstr "当命令存在："
+msgstr "在命令退出时："
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
-msgstr ""
+msgstr "使用一个登录 shell"
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>命令</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
 "chrome' or to use the generic commands 'x-www-browser' and 'xdg-open'. The "
 "best command may be different depending on the system."
 msgstr ""
+"* 必须在这里输入一个可打开浏览器的有效命令。可以使用特定浏览器的名称，"
+"如“firefox”或“google-chrome”，也可以使用通用命令，如“x-www-browser”或“xdg-"
+"open”。最佳命令和具体系统相关。"
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
-msgstr ""
+msgstr "关闭标签页时显示确认对话框"
 
-#: src/tilda.ui:1467
-#, fuzzy
+#: src/tilda.ui:1459
 msgid "Close Action"
-msgstr "关闭标签(_C)"
+msgstr "关闭行为"
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "标题和命令"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "百分比"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "按像素计"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>高度</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
-msgstr ""
+msgstr "监视器："
 
-#: src/tilda.ui:1673
-#, fuzzy
+#: src/tilda.ui:1665
 msgid "<b>Select monitor</b>"
-msgstr "<b>标题</b>"
+msgstr "<b>选择监视器</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>宽度</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "水平居中"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Y轴位置"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "X轴位置"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "垂直居中"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>位置</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
-msgstr "标签位置："
+msgstr "标签页位置："
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
-msgstr ""
+msgstr "展开标签页"
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
-msgstr ""
+msgstr "显示单个标签页"
 
-#: src/tilda.ui:1987
-#, fuzzy
+#: src/tilda.ui:1976
 msgid "<b>Tabs</b>"
-msgstr "<b>标题</b>"
+msgstr "<b>标签页</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "动画延迟（微秒）"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "动画方向"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "使用图片作为背景"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "下拉动画"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "透明度"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "启用透明"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>额外</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "外观"
 
-#: src/tilda.ui:2248
-#, fuzzy
+#: src/tilda.ui:2212
 msgid "Cursor Color"
-msgstr "光标闪烁"
+msgstr "光标颜色"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "文字颜色"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "背景颜色"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr "内置方案"
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr "<b>前景和背景颜色</b>"
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
+"<small><i><b>注意：</b>终端应用程序选择的颜色可能有所不同。</i></small>"
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
-msgstr ""
+msgstr "选择颜色 14"
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
-msgstr ""
+msgstr "选择颜色 13"
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
-msgstr ""
+msgstr "选择颜色 15"
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
-msgstr ""
+msgstr "选择颜色 12"
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
-msgstr ""
+msgstr "选择颜色 10"
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
-msgstr ""
+msgstr "选择颜色 11"
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
-msgstr ""
+msgstr "选择颜色 9"
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
-msgstr ""
+msgstr "选择颜色 7"
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
-msgstr ""
+msgstr "选择颜色 6"
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
-msgstr ""
+msgstr "选择颜色 5"
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
-msgstr ""
+msgstr "选择颜色 4"
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
-msgstr ""
+msgstr "选择颜色 3"
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
-msgstr ""
+msgstr "选择颜色 2"
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
-msgstr ""
+msgstr "选择颜色 1"
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
-msgstr ""
+msgstr "选择颜色 0"
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
-msgstr ""
+msgstr "选择颜色 8"
 
-#: src/tilda.ui:2622
-#, fuzzy
+#: src/tilda.ui:2586
 msgid "Built-in schemes:"
-msgstr "内置方案"
+msgstr "内置方案："
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
-msgstr ""
+msgstr "调色板："
 
-#: src/tilda.ui:2653
-#, fuzzy
+#: src/tilda.ui:2617
 msgid "<b>Palette</b>"
-msgstr "<b>标题</b>"
+msgstr "<b>调色板</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "颜色"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "滚动条位于:"
 
-#: src/tilda.ui:2738
-#, fuzzy
+#: src/tilda.ui:2702
 msgid "Limit scrollback to:"
-msgstr "回滚:"
+msgstr "限制回滚数量："
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
-msgstr ""
+msgstr "取消选择以设置为无限回滚。"
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "输出时滚动"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr "击键时滚动"
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "滚动背景"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
-msgstr ""
+msgstr "0"
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "行"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>滚动</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "滚动"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -619,55 +625,54 @@ msgstr ""
 "<small><i><b>注意：</b>这些选项可能造成一些应用程序产生不正确的行为。仅用于允"
 "许您在一些应用程序和操作系统中作调整以获得不同的终端行为。</i></small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
-msgstr "按Backspace键产生(_B)"
+msgstr "按 Backspace 键产生(_B)："
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
-msgstr "按Detelet键产生(_D):"
+msgstr "按 Delete 键产生(_D)："
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "重置兼容性选项为默认值(_R)"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>兼容性</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "兼容性"
 
-#: src/tilda.ui:3072
-#, fuzzy
+#: src/tilda.ui:3019
 msgid "<b>Keybindings</b>"
-msgstr "键绑定"
+msgstr "<b>键绑定</b>"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "键绑定"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
-msgstr ""
+msgstr "搜索内容未找到，再次搜索以从开始位置继续。"
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
-msgstr ""
+msgstr "下一个(_N)"
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
-msgstr ""
+msgstr "上一个(_P)"
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
-msgstr ""
+msgstr "区分大小写(_M)"
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
-msgstr ""
+msgstr "正则表达式(_R)"
 
 #: src/configsys.c:365
 msgid "Unable to sync the config file to disk\n"
@@ -687,61 +692,52 @@ msgstr "无法将配置文件写入%s\n"
 msgid "Unable to run command: `%s'\n"
 msgstr "无法执行命令：`%s'\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr "无法打开锁定的目录：%s\n"
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "使用平滑字体"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "设置背景颜色"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "启动时运行命令"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "使用如下字符串的字体"
 
-#: src/tilda.c:331
-#, fuzzy
+#: src/tilda.c:330
 msgid "Configuration file"
-msgstr "显示配置向导"
+msgstr "配置文件"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "回滚行"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "使用滚动条"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "显示版本号后退出"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "设定初始工作目录"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "设置背景图片"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "不透明: 0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "显示配置向导"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -754,8 +750,8 @@ msgstr ""
 "\n"
 "错误信息：%s\n"
 
-#: src/tilda.c:396
-#, fuzzy, c-format
+#: src/tilda.c:390
+#, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
 "all\"\n"
@@ -763,131 +759,162 @@ msgid ""
 "\n"
 "Error message: %s\n"
 msgstr ""
-"解析命令行参数时出错。请尝试\"tilda --help\"\n"
+"解析 Glib 和 GTK 特有的命令行选项时出错。请尝试“tilda --help-all”\n"
 "来获得所有可用选项。\n"
 "\n"
 "错误信息：%s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
-msgstr ""
+msgstr "为新的 tilda_cli-options 结构体分配内存时出错。\n"
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
-msgstr ""
+msgstr "正在创建目录：“%s”\n"
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
-msgstr ""
+msgstr "在用户配置目录中找到了 style.css，将应用用户 css 风格。\n"
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
-msgstr ""
+msgstr "正在将旧的配置路径迁移至 XDG 文件夹中\n"
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
-msgstr ""
+msgstr "指定的配置文件“%s”不存在。回退到默认路径。\n"
 
-#: src/tilda.c:878
-#, fuzzy
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
-msgstr "键绑定无效。请重新选择。"
+msgstr "您为“拉下终端”所选择的键绑定无效。请重新选择。"
 
-#: src/tilda_terminal.c:419
-#, fuzzy, c-format
+#: src/tilda-keybinding.c:115
+msgid "Action"
+msgstr "动作"
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr "快捷键"
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr "输入键盘快捷键"
+
+#: src/tilda-keybinding.c:417
+#, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr "您为“%s”所选择的键绑定无效。请重新选择。"
+
+#: src/tilda_terminal.c:397
+#, c-format
 msgid "Problem reading link %s: %s\n"
-msgstr "解析自定义命令错误：%s\n"
+msgstr "读取链接 %s 时出错：%s\n"
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr "解析自定义命令错误：%s\n"
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr "运行默认shell作为替代\n"
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr "无法执行自定义命令：%s\n"
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
-msgstr "无法运行默认shell：%s\n"
+msgstr "无法启动默认 shell：%s\n"
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
-msgstr "无法运行web浏览器。该命令是'%s'\n"
+msgstr "无法运行 web 浏览器。命令是“%s”\n"
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "未命名"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
-msgstr "配置文件中\"d_set_title\"的值有误\n"
+msgstr "配置文件中“d_set_title”的值有误\n"
 
 #: src/tilda_window.c:101
 msgid "Are you sure you want to close this tab?"
-msgstr ""
+msgstr "您确认要关闭此标签页吗？"
 
 #: src/tilda_window.c:148
 msgid "You have a bad tab_pos in your configuration file\n"
-msgstr "在你的配置文件中有一个错误的标签位置\n"
+msgstr "您的配置文件中指定了错误的 tab_pos\n"
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
-msgstr "无法设置tilda的图标: %s\n"
+msgstr "无法设置 tilda 的图标：%s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "内存不够，无法创建标签页\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
-msgstr ""
+msgstr "您确认要退出吗？"
 
 #: src/wizard.c:219
 msgid "Tango"
-msgstr ""
+msgstr "Tango"
 
 #: src/wizard.c:220
 msgid "Linux console"
-msgstr ""
+msgstr "Linux 控制台"
 
 #: src/wizard.c:221
 msgid "XTerm"
-msgstr ""
+msgstr "XTerm"
 
 #: src/wizard.c:222
 msgid "Rxvt"
-msgstr ""
+msgstr "Rxvt"
 
-#: src/wizard.c:340
-#, fuzzy, c-format
+#: src/wizard.c:336
+#, c-format
 msgid "Tilda %d Config"
-msgstr "Tilda设置"
+msgstr "Tilda %d 配置"
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
-msgstr ""
+#: src/wizard.c:767
+msgid "Invalid Cursor Type, resetting to default\n"
+msgstr "无效的光标类型，重置为默认\n"
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
-msgstr ""
+msgstr "无效的非焦点拉起行为，忽略\n"
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
-msgstr "无效标签位置，忽略\n"
+msgstr "无效标签页位置，忽略\n"
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "启用字体抗锯齿"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "使用图片作为背景"
+
+#~ msgid "Scroll Background"
+#~ msgstr "滚动背景"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "使用平滑字体"
+
+#~ msgid "Set Background Image"
+#~ msgstr "设置背景图片"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "启用双重缓存"
@@ -896,20 +923,8 @@ msgstr "无效标签位置，忽略\n"
 #~ msgstr "    "
 
 #, fuzzy
-#~ msgid "<b>Paste</b>"
-#~ msgstr "<b>标题</b>"
-
-#, fuzzy
-#~ msgid "<b>Quit</b>"
-#~ msgstr "<b>标题</b>"
-
-#, fuzzy
 #~ msgid "<b>Close Tab</b>"
 #~ msgstr "关闭标签(_C)"
-
-#, fuzzy
-#~ msgid "<b>Copy</b>"
-#~ msgstr "<b>字体</b>"
 
 #, fuzzy
 #~ msgid "<b>Pull Down Terminal</b>"
@@ -926,12 +941,6 @@ msgstr "无效标签位置，忽略\n"
 #, fuzzy
 #~ msgid "Problem when opening config file\n"
 #~ msgstr "解析配置文件错误\n"
-
-#~ msgid "_New Tab"
-#~ msgstr "新建标签(_N)"
-
-#~ msgid "_Close Tab"
-#~ msgstr "关闭标签(_C)"
 
 #, fuzzy
 #~ msgid ""
@@ -972,11 +981,6 @@ msgstr "无效标签位置，忽略\n"
 #, fuzzy
 #~ msgid ""
 #~ "The keybinding you chose for \"Copy\" is invalid. Please choose another."
-#~ msgstr "键绑定无效。请重新选择。"
-
-#, fuzzy
-#~ msgid ""
-#~ "The keybinding you chose for \"Paste\" is invalid. Please choose another."
 #~ msgstr "键绑定无效。请重新选择。"
 
 #, fuzzy

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tilda\n"
 "Report-Msgid-Bugs-To: sloutri@iit.edu\n"
-"POT-Creation-Date: 2018-02-08 20:52+0100\n"
+"POT-Creation-Date: 2018-03-19 12:38+0800\n"
 "PO-Revision-Date: 2017-07-18 00:31+0800\n"
 "Last-Translator: Kuang-Lin Pan <andypan@ntuosc.org>\n"
 "Language-Team: Chinese (Traditional) <zh_TW@li.org>\n"
@@ -17,6 +17,39 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2017-07-17 11:20+0000\n"
 "X-Generator: Poedit 1.8.9\n"
+
+#: src/menu.ui:6
+msgid "_New Tab"
+msgstr "新分頁(_N)"
+
+#: src/menu.ui:10
+#, fuzzy
+msgid "_Close Tab"
+msgstr "關閉 Tilda"
+
+#: src/menu.ui:16
+msgid "_Copy"
+msgstr ""
+
+#: src/menu.ui:20
+msgid "_Paste"
+msgstr ""
+
+#: src/menu.ui:26
+msgid "_Toggle Fullscreen"
+msgstr ""
+
+#: src/menu.ui:30
+msgid "_Toggle Searchbar"
+msgstr ""
+
+#: src/menu.ui:36
+msgid "_Preferences"
+msgstr ""
+
+#: src/menu.ui:42
+msgid "_Quit"
+msgstr ""
 
 #: src/tilda.ui:69
 msgid "Close Tilda"
@@ -30,19 +63,19 @@ msgstr "開啟新的終端機"
 msgid "Open a new terminal and hide"
 msgstr "開啟新的終端機並隱藏"
 
-#: src/tilda.ui:86 src/tilda.ui:177
+#: src/tilda.ui:86 src/tilda.ui:194
 msgid "Top"
 msgstr "頂部"
 
-#: src/tilda.ui:89 src/tilda.ui:180
+#: src/tilda.ui:89 src/tilda.ui:197
 msgid "Bottom"
 msgstr "底部"
 
-#: src/tilda.ui:92 src/tilda.ui:183
+#: src/tilda.ui:92 src/tilda.ui:200
 msgid "Left"
 msgstr "左側"
 
-#: src/tilda.ui:95 src/tilda.ui:186
+#: src/tilda.ui:95 src/tilda.ui:203
 msgid "Right"
 msgstr "右側"
 
@@ -71,106 +104,106 @@ msgid "Underline Cursor"
 msgstr "底線狀游標"
 
 #: src/tilda.ui:140
-msgid "Isn't displayed"
-msgstr "不顯示"
-
-#: src/tilda.ui:143
-msgid "Goes after initial title"
-msgstr "接在初始標題之後"
-
-#: src/tilda.ui:146
-msgid "Goes before initial title"
-msgstr "接在初始標題之前"
-
-#: src/tilda.ui:149
-msgid "Replace initial title"
-msgstr "取代初始標題"
-
-#: src/tilda.ui:160
-msgid "Drop to the default shell"
-msgstr "啟動預設的命令解釋器"
-
-#: src/tilda.ui:163
-msgid "Restart the command"
-msgstr "重新執行指令"
-
-#: src/tilda.ui:166
-msgid "Exit the terminal"
-msgstr "離開終端機"
-
-#: src/tilda.ui:197 src/tilda.ui:229 src/wizard.c:218
-msgid "Custom"
-msgstr "自訂"
-
-#: src/tilda.ui:200
-msgid "Green on Black"
-msgstr "黑底綠字"
-
-#: src/tilda.ui:203
-msgid "Black on White"
-msgstr "白底黑字"
-
-#: src/tilda.ui:206
-msgid "White on Black"
-msgstr "黑底白字"
-
-#: src/tilda.ui:209 src/wizard.c:223
-msgid "Zenburn"
-msgstr "Zenburn"
-
-#: src/tilda.ui:212 src/wizard.c:224
-msgid "Solarized Light"
-msgstr "Solarized Light"
-
-#: src/tilda.ui:215 src/wizard.c:225
-msgid "Solarized Dark"
-msgstr "Solarized Dark"
-
-#: src/tilda.ui:218 src/wizard.c:226
-msgid "Snazzy"
-msgstr ""
-
-#: src/tilda.ui:240
-msgid "On the Left"
-msgstr "置左"
-
-#: src/tilda.ui:243
-msgid "On the Right"
-msgstr "置右"
-
-#: src/tilda.ui:246
-msgid "Disabled"
-msgstr "停用"
-
-#: src/tilda.ui:257 src/tilda.ui:274
-msgid "ASCII DEL"
-msgstr "ASCII DEL"
-
-#: src/tilda.ui:260 src/tilda.ui:277
-msgid "Escape sequence"
-msgstr "「跳脫字元」序列"
-
-#: src/tilda.ui:263 src/tilda.ui:280
-msgid "Control-H"
-msgstr "Control-H"
-
-#: src/tilda.ui:291
 msgid "Show whole tab title"
 msgstr ""
 
-#: src/tilda.ui:294
+#: src/tilda.ui:143
 msgid "Show first n chars of title"
 msgstr ""
 
-#: src/tilda.ui:297
+#: src/tilda.ui:146
 msgid "Show last n chars of title"
 msgstr ""
+
+#: src/tilda.ui:157
+msgid "Isn't displayed"
+msgstr "不顯示"
+
+#: src/tilda.ui:160
+msgid "Goes after initial title"
+msgstr "接在初始標題之後"
+
+#: src/tilda.ui:163
+msgid "Goes before initial title"
+msgstr "接在初始標題之前"
+
+#: src/tilda.ui:166
+msgid "Replace initial title"
+msgstr "取代初始標題"
+
+#: src/tilda.ui:177
+msgid "Drop to the default shell"
+msgstr "啟動預設的命令解釋器"
+
+#: src/tilda.ui:180
+msgid "Restart the command"
+msgstr "重新執行指令"
+
+#: src/tilda.ui:183
+msgid "Exit the terminal"
+msgstr "離開終端機"
+
+#: src/tilda.ui:214 src/tilda.ui:246 src/wizard.c:218
+msgid "Custom"
+msgstr "自訂"
+
+#: src/tilda.ui:217
+msgid "Green on Black"
+msgstr "黑底綠字"
+
+#: src/tilda.ui:220
+msgid "Black on White"
+msgstr "白底黑字"
+
+#: src/tilda.ui:223
+msgid "White on Black"
+msgstr "黑底白字"
+
+#: src/tilda.ui:226 src/wizard.c:223
+msgid "Zenburn"
+msgstr "Zenburn"
+
+#: src/tilda.ui:229 src/wizard.c:224
+msgid "Solarized Light"
+msgstr "Solarized Light"
+
+#: src/tilda.ui:232 src/wizard.c:225
+msgid "Solarized Dark"
+msgstr "Solarized Dark"
+
+#: src/tilda.ui:235 src/wizard.c:226
+msgid "Snazzy"
+msgstr ""
+
+#: src/tilda.ui:257
+msgid "On the Left"
+msgstr "置左"
+
+#: src/tilda.ui:260
+msgid "On the Right"
+msgstr "置右"
+
+#: src/tilda.ui:263
+msgid "Disabled"
+msgstr "停用"
+
+#: src/tilda.ui:274 src/tilda.ui:291
+msgid "ASCII DEL"
+msgstr "ASCII DEL"
+
+#: src/tilda.ui:277 src/tilda.ui:294
+msgid "Escape sequence"
+msgstr "「跳脫字元」序列"
+
+#: src/tilda.ui:280 src/tilda.ui:297
+msgid "Control-H"
+msgstr "Control-H"
 
 #: src/tilda.ui:314
 msgid "Tilda Config"
 msgstr "Tilda 設定值"
 
-#: src/tilda.ui:392 src/tilda.c:329
+#: src/tilda.ui:392 src/tilda.c:328
 msgid "Start Tilda hidden"
 msgstr "啟動 Tilda 時隱藏"
 
@@ -202,138 +235,134 @@ msgstr "以全螢幕啟動"
 msgid "Non-focus Pull Up Behaviour:"
 msgstr "未取得焦點時的拉起行為："
 
-#: src/tilda.ui:554
+#: src/tilda.ui:557
 msgid "<b>Window Display</b>"
 msgstr "<b>視窗顯示</b>"
 
-#: src/tilda.ui:592
+#: src/tilda.ui:595
 msgid "Cursor Blinks"
 msgstr "閃爍游標"
 
-#: src/tilda.ui:606
+#: src/tilda.ui:609
 msgid "Audible Terminal Bell"
 msgstr "終端機會發出響聲"
 
-#: src/tilda.ui:622
+#: src/tilda.ui:625
 msgid "Cursor Shape: "
 msgstr "游標形狀："
 
-#: src/tilda.ui:657
+#: src/tilda.ui:660
 msgid "<b>Terminal Display</b>"
 msgstr "<b>終端機顯示</b>"
 
-#: src/tilda.ui:695
-msgid "Enable Antialiasing"
-msgstr "啟用抗鋸齒"
-
-#: src/tilda.ui:709
+#: src/tilda.ui:698
 msgid "Allow Bold Text"
 msgstr "允許粗體字"
 
-#: src/tilda.ui:739
+#: src/tilda.ui:728
 msgid "Font:"
 msgstr "字型："
 
-#: src/tilda.ui:755
+#: src/tilda.ui:747
 msgid "<b>Font</b>"
 msgstr "<b>字型</b>"
 
-#: src/tilda.ui:804
+#: src/tilda.ui:796
 msgid "Hide Tilda when mouse leaves it"
 msgstr "滑鼠離開時隱藏 Tilda"
 
-#: src/tilda.ui:821
+#: src/tilda.ui:813
 msgid "Auto Hide Delay:"
 msgstr "自動隱藏延遲："
 
-#: src/tilda.ui:831
+#: src/tilda.ui:823
 msgid "Hide when Tilda loses focus"
 msgstr "在 Tilda 失去焦點時隱藏"
 
-#: src/tilda.ui:851
+#: src/tilda.ui:843
 msgid "<b>Auto Hide</b>"
 msgstr "<b>自動隱藏</b>"
 
-#: src/tilda.ui:890
+#: src/tilda.ui:882
 msgid "When last terminal is closed:"
 msgstr "當最後一個終端機被關閉："
 
-#: src/tilda.ui:917
+#: src/tilda.ui:909
 #, fuzzy
 msgid "Always prompt on exit"
 msgstr "永遠顯示在最上層"
 
-#: src/tilda.ui:937
+#: src/tilda.ui:932
 msgid "<b>Program Exit</b>"
 msgstr "<b>程式離開</b>"
 
-#: src/tilda.ui:955
+#: src/tilda.ui:950
 msgid ""
 "<small><i><b>Note:</b> Some options require that tilda is restarted.</i></"
 "small>"
 msgstr "<small><i><b>注意：</b>有些選項需要重新啟動 tilda。</i></small>"
 
-#: src/tilda.ui:972
+#: src/tilda.ui:967
 msgid "General"
 msgstr "一般"
 
-#: src/tilda.ui:1017
+#: src/tilda.ui:1012
 msgid "Word Characters:"
 msgstr "視為單字的字元："
 
-#: src/tilda.ui:1045
+#: src/tilda.ui:1040
 msgid "<b>Select by Word</b>"
 msgstr "<b>以單字為單位選取</b>"
 
-#: src/tilda.ui:1095
+#: src/tilda.ui:1090
 msgid "Web Browser *:"
 msgstr "網頁瀏覽器 *："
 
-#: src/tilda.ui:1112
+#: src/tilda.ui:1107
 msgid "<b>URL Handling</b>"
 msgstr "<b>URL 處理方式</b>"
 
-#: src/tilda.ui:1147
+#: src/tilda.ui:1142
 msgid "Initial Title:"
 msgstr "初始標題："
 
-#: src/tilda.ui:1169
+#: src/tilda.ui:1164
 msgid "Title Max Length:"
 msgstr ""
 
-#: src/tilda.ui:1210
+#: src/tilda.ui:1205
 msgid "Dynamically-set Title:"
 msgstr "動態設定標題："
 
-#: src/tilda.ui:1222
+#: src/tilda.ui:1217
 msgid "Title Behaviour:"
 msgstr ""
 
-#: src/tilda.ui:1255
+#: src/tilda.ui:1250
 msgid "<b>Title</b>"
 msgstr "<b>標題</b>"
 
-#: src/tilda.ui:1316
+#: src/tilda.ui:1311
 msgid "Run a custom command instead of the shell"
 msgstr "執行自訂的指令而不是執行命令解釋器"
 
-#: src/tilda.ui:1332
+#: src/tilda.ui:1327
 msgid "Custom Command:"
 msgstr "自訂指令："
 
-#: src/tilda.ui:1344
+#: src/tilda.ui:1339
 msgid "When Command Exits:"
 msgstr "當指令結束後："
 
-#: src/tilda.ui:1354
+#: src/tilda.ui:1349
 msgid "Use a login shell"
 msgstr "使用登入的命令解釋器"
 
-#: src/tilda.ui:1380
+#: src/tilda.ui:1375
 msgid "<b>Command</b>"
 msgstr "<b>指令</b>"
 
-#: src/tilda.ui:1407
+#: src/tilda.ui:1402
 msgid ""
 "* A valid command that can open a browser must be entered here. It is "
 "possible to use the name of a specific browser such as 'firefox' and 'google-"
@@ -344,260 +373,252 @@ msgstr ""
 "'firefox'、'google-chrome'，或使用通用的指令 'x-www-browser'、'xdg-open'。最"
 "適合的指令視作業系統而定。"
 
-#: src/tilda.ui:1444
+#: src/tilda.ui:1439
 msgid "Show confirmation dialog when closing tab"
 msgstr ""
 
-#: src/tilda.ui:1467
+#: src/tilda.ui:1459
 #, fuzzy
 msgid "Close Action"
 msgstr "關閉 Tilda"
 
-#: src/tilda.ui:1488
+#: src/tilda.ui:1480
 msgid "Title and Command"
 msgstr "標題及指令"
 
-#: src/tilda.ui:1532 src/tilda.ui:1709
+#: src/tilda.ui:1524 src/tilda.ui:1701
 msgid "Percentage"
 msgstr "百分比"
 
-#: src/tilda.ui:1555 src/tilda.ui:1721
+#: src/tilda.ui:1547 src/tilda.ui:1713
 msgid "In Pixels"
 msgstr "以像素為單位"
 
-#: src/tilda.ui:1582
+#: src/tilda.ui:1574
 msgid "<b>Height</b>"
 msgstr "<b>高度</b>"
 
-#: src/tilda.ui:1618
+#: src/tilda.ui:1610
 msgid "Monitor:"
 msgstr "螢幕："
 
-#: src/tilda.ui:1673
+#: src/tilda.ui:1665
 msgid "<b>Select monitor</b>"
 msgstr "<b>選擇螢幕</b>"
 
-#: src/tilda.ui:1759
+#: src/tilda.ui:1751
 msgid "<b>Width</b>"
 msgstr "<b>寬度</b>"
 
-#: src/tilda.ui:1795
+#: src/tilda.ui:1787
 msgid "Centered Horizontally"
 msgstr "水平置中"
 
-#: src/tilda.ui:1813 src/tilda.c:337
+#: src/tilda.ui:1805 src/tilda.c:336
 msgid "Y Position"
 msgstr "Y 座標位置"
 
-#: src/tilda.ui:1847 src/tilda.c:336
+#: src/tilda.ui:1839 src/tilda.c:335
 msgid "X Position"
 msgstr "X 座標位置"
 
-#: src/tilda.ui:1857
+#: src/tilda.ui:1849
 msgid "Centered Vertically"
 msgstr "垂直置中"
 
-#: src/tilda.ui:1885
+#: src/tilda.ui:1877
 msgid "<b>Position</b>"
 msgstr "<b>位置</b>"
 
-#: src/tilda.ui:1923
+#: src/tilda.ui:1915
 msgid "Position of Tabs:"
 msgstr "頁籤位置："
 
-#: src/tilda.ui:1950
+#: src/tilda.ui:1942
 msgid "Expand Tabs"
 msgstr ""
 
-#: src/tilda.ui:1964
+#: src/tilda.ui:1956
 msgid "Show single Tab"
 msgstr ""
 
-#: src/tilda.ui:1987
+#: src/tilda.ui:1976
 #, fuzzy
 msgid "<b>Tabs</b>"
 msgstr "<b>額外選項</b>"
 
-#: src/tilda.ui:2036
+#: src/tilda.ui:2025
 msgid "Animation Delay (usec)"
 msgstr "動畫延遲 (微秒)"
 
-#: src/tilda.ui:2048
+#: src/tilda.ui:2037
 msgid "Animation Orientation"
 msgstr "動畫起始點"
 
-#: src/tilda.ui:2097
-msgid "Use Image for Background"
-msgstr "使用圖像做為背景"
-
-#: src/tilda.ui:2111
+#: src/tilda.ui:2075
 msgid "Animated Pulldown"
 msgstr "動畫"
 
-#: src/tilda.ui:2127
+#: src/tilda.ui:2091
 msgid "Level of Transparency"
 msgstr "透明等級"
 
-#: src/tilda.ui:2137
+#: src/tilda.ui:2101
 msgid "Enable Transparency"
 msgstr "啟用透明度"
 
-#: src/tilda.ui:2160
+#: src/tilda.ui:2124
 msgid "<b>Extras</b>"
 msgstr "<b>額外選項</b>"
 
-#: src/tilda.ui:2179
+#: src/tilda.ui:2143
 msgid "Appearance"
 msgstr "外觀"
 
-#: src/tilda.ui:2248
+#: src/tilda.ui:2212
 msgid "Cursor Color"
 msgstr "游標顏色"
 
-#: src/tilda.ui:2296
+#: src/tilda.ui:2260
 msgid "Text Color"
 msgstr "文字色彩"
 
-#: src/tilda.ui:2308
+#: src/tilda.ui:2272
 msgid "Background Color"
 msgstr "背景顏色"
 
-#: src/tilda.ui:2320
+#: src/tilda.ui:2284
 msgid "Built-in Schemes"
 msgstr "內建佈景"
 
-#: src/tilda.ui:2334
+#: src/tilda.ui:2298
 msgid "<b>Foreground and Background Colors</b>"
 msgstr "<b>前景和背景顏色</b>"
 
-#: src/tilda.ui:2366
+#: src/tilda.ui:2330
 msgid ""
 "<small><i><b>Note:</b> Terminal applications have these colors available to "
 "them.</i></small>"
 msgstr ""
 "<small><i><b>注意：</b>終端機應用程式會使用以下提供的顏色。</i></small>"
 
-#: src/tilda.ui:2409
+#: src/tilda.ui:2373
 msgid "Choose Color 14"
 msgstr "選擇顏色 14"
 
-#: src/tilda.ui:2422
+#: src/tilda.ui:2386
 msgid "Choose Color 13"
 msgstr "選擇顏色 13"
 
-#: src/tilda.ui:2435
+#: src/tilda.ui:2399
 msgid "Choose Color 15"
 msgstr "選擇顏色 15"
 
-#: src/tilda.ui:2448
+#: src/tilda.ui:2412
 msgid "Choose Color 12"
 msgstr "選擇顏色 12"
 
-#: src/tilda.ui:2461
+#: src/tilda.ui:2425
 msgid "Choose Color 10"
 msgstr "選擇顏色 10"
 
-#: src/tilda.ui:2474
+#: src/tilda.ui:2438
 msgid "Choose Color 11"
 msgstr "選擇顏色 11"
 
-#: src/tilda.ui:2487
+#: src/tilda.ui:2451
 msgid "Choose Color 9"
 msgstr "選擇顏色 9"
 
-#: src/tilda.ui:2500
+#: src/tilda.ui:2464
 msgid "Choose Color 7"
 msgstr "選擇顏色 7"
 
-#: src/tilda.ui:2513
+#: src/tilda.ui:2477
 msgid "Choose Color 6"
 msgstr "選擇顏色 6"
 
-#: src/tilda.ui:2526
+#: src/tilda.ui:2490
 msgid "Choose Color 5"
 msgstr "選擇顏色 5"
 
-#: src/tilda.ui:2539
+#: src/tilda.ui:2503
 msgid "Choose Color 4"
 msgstr "選擇顏色 4"
 
-#: src/tilda.ui:2552
+#: src/tilda.ui:2516
 msgid "Choose Color 3"
 msgstr "選擇顏色 3"
 
-#: src/tilda.ui:2565
+#: src/tilda.ui:2529
 msgid "Choose Color 2"
 msgstr "選擇顏色 2"
 
-#: src/tilda.ui:2578
+#: src/tilda.ui:2542
 msgid "Choose Color 1"
 msgstr "選擇顏色 1"
 
-#: src/tilda.ui:2591
+#: src/tilda.ui:2555
 msgid "Choose Color 0"
 msgstr "Choose Color 0"
 
-#: src/tilda.ui:2605
+#: src/tilda.ui:2569
 msgid "Choose Color 8"
 msgstr "Choose Color 8"
 
-#: src/tilda.ui:2622
+#: src/tilda.ui:2586
 msgid "Built-in schemes:"
 msgstr "內建佈景："
 
-#: src/tilda.ui:2637
+#: src/tilda.ui:2601
 msgid "Color palette:"
 msgstr "調色盤："
 
-#: src/tilda.ui:2653
+#: src/tilda.ui:2617
 msgid "<b>Palette</b>"
 msgstr "<b>調色盤</b>"
 
-#: src/tilda.ui:2672
+#: src/tilda.ui:2636
 msgid "Colors"
 msgstr "色彩"
 
-#: src/tilda.ui:2729
+#: src/tilda.ui:2693
 msgid "Scrollbar is:"
 msgstr "捲軸在："
 
-#: src/tilda.ui:2738
+#: src/tilda.ui:2702
 msgid "Limit scrollback to:"
 msgstr "限制回捲行數："
 
-#: src/tilda.ui:2742
+#: src/tilda.ui:2706
 msgid "Unselect for unlimited scrollback."
 msgstr "取消選擇視為無限制回捲行數。"
 
-#: src/tilda.ui:2754
+#: src/tilda.ui:2718
 msgid "Scroll on Output"
 msgstr "輸出時捲動"
 
-#: src/tilda.ui:2768
+#: src/tilda.ui:2732
 msgid "Scroll on Keystroke"
 msgstr "打字時捲動"
 
-#: src/tilda.ui:2782
-msgid "Scroll Background"
-msgstr "捲動背景"
-
-#: src/tilda.ui:2804
+#: src/tilda.ui:2754
 msgid "0"
 msgstr "0"
 
-#: src/tilda.ui:2816
+#: src/tilda.ui:2766
 msgid "lines"
 msgstr "行"
 
-#: src/tilda.ui:2845
+#: src/tilda.ui:2792
 msgid "<b>Scrolling</b>"
 msgstr "<b>捲動</b>"
 
-#: src/tilda.ui:2866
+#: src/tilda.ui:2813
 msgid "Scrolling"
 msgstr "捲動方式"
 
-#: src/tilda.ui:2905
+#: src/tilda.ui:2852
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -608,52 +629,52 @@ msgstr ""
 "某些應用程式及作業系統需要不同的終端機運作方式時，提供暫時的解決方法。</i></"
 "small>"
 
-#: src/tilda.ui:2921
+#: src/tilda.ui:2868
 msgid "_Backspace key generates:"
 msgstr "後退鍵會產生(_B)："
 
-#: src/tilda.ui:2935
+#: src/tilda.ui:2882
 msgid "_Delete key generates:"
 msgstr "刪除鍵會產生(_D)："
 
-#: src/tilda.ui:2947
+#: src/tilda.ui:2894
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "將有關相容性的選項重設為預設值(_R)"
 
-#: src/tilda.ui:3001
+#: src/tilda.ui:2948
 msgid "<b>Compatibility</b>"
 msgstr "<b>相容性</b>"
 
-#: src/tilda.ui:3020
+#: src/tilda.ui:2967
 msgid "Compatibility"
 msgstr "相容性"
 
-#: src/tilda.ui:3072
+#: src/tilda.ui:3019
 msgid "<b>Keybindings</b>"
 msgstr "<b>按鍵對應</b>"
 
-#: src/tilda.ui:3091
+#: src/tilda.ui:3038
 msgid "Keybindings"
 msgstr "按鍵對應"
 
-#: src/tilda.ui:3123
+#: src/tilda.ui:3070
 msgid ""
 "Search term not found, search again to continue the search at the beginning."
 msgstr "找不到搜尋詞，再次搜尋來繼續從起始位置搜尋。"
 
-#: src/tilda.ui:3157
+#: src/tilda.ui:3104
 msgid "_Next"
 msgstr "下一個 (_N)"
 
-#: src/tilda.ui:3172
+#: src/tilda.ui:3119
 msgid "_Prev"
 msgstr "上一個 (_P)"
 
-#: src/tilda.ui:3187
+#: src/tilda.ui:3134
 msgid "_Match Case"
 msgstr "比對大小寫 (_M)"
 
-#: src/tilda.ui:3204
+#: src/tilda.ui:3151
 msgid "_Regex"
 msgstr "使用正規表示式 (_R)"
 
@@ -675,60 +696,52 @@ msgstr "無法將設定檔寫至 %s\n"
 msgid "Unable to run command: `%s'\n"
 msgstr "無法執行指令：`%s'\n"
 
-#: src/tilda.c:276 src/tilda.c:566
+#: src/tilda.c:276 src/tilda.c:545
 #, c-format
 msgid "Unable to open lock directory: %s\n"
 msgstr "無法開啟鎖定的目錄：%s\n"
 
 #: src/tilda.c:326
-msgid "Use Antialiased Fonts"
-msgstr "使用抗鋸齒字型"
-
-#: src/tilda.c:327
 msgid "Set the background color"
 msgstr "設定背景顏色"
 
-#: src/tilda.c:328
+#: src/tilda.c:327
 msgid "Run a command at startup"
 msgstr "啟動時執行指令"
 
-#: src/tilda.c:330
+#: src/tilda.c:329
 msgid "Set the font to the following string"
 msgstr "將字型設定至以下字串"
 
-#: src/tilda.c:331
+#: src/tilda.c:330
 msgid "Configuration file"
 msgstr "設定檔"
 
-#: src/tilda.c:332
+#: src/tilda.c:331
 msgid "Scrollback Lines"
 msgstr "回捲行數"
 
-#: src/tilda.c:333
+#: src/tilda.c:332
 msgid "Use Scrollbar"
 msgstr "使用捲軸"
 
-#: src/tilda.c:334
+#: src/tilda.c:333
 msgid "Print the version, then exit"
 msgstr "列印版本號，然後離開"
 
-#: src/tilda.c:335
+#: src/tilda.c:334
 msgid "Set Initial Working Directory"
 msgstr "設定初始工作目錄"
 
-#: src/tilda.c:339
-msgid "Set Background Image"
-msgstr "設定背景圖片"
-
-#: src/tilda.c:340 src/tilda.c:342
+#: src/tilda.c:337
 msgid "Opaqueness: 0-100%"
 msgstr "不透明度：0-100%"
 
-#: src/tilda.c:344
+#: src/tilda.c:338
 msgid "Show Configuration Wizard"
 msgstr "顯示設定精靈"
 
-#: src/tilda.c:358
+#: src/tilda.c:352
 #, c-format
 msgid ""
 "Error parsing command-line options. Try \"tilda --help\"\n"
@@ -741,7 +754,7 @@ msgstr ""
 "\n"
 "錯誤訊息：%s\n"
 
-#: src/tilda.c:396
+#: src/tilda.c:390
 #, c-format
 msgid ""
 "Error parsing Glib and GTK specific command-line options. Try \"tilda --help-"
@@ -755,69 +768,87 @@ msgstr ""
 "\n"
 "錯誤訊息：%s\n"
 
-#: src/tilda.c:415
+#: src/tilda.c:409
 msgid "Error allocating memory for a new tilda_cli_options structure.\n"
 msgstr "取得記憶體用於新的 tilda_cli_options 結構時發生錯誤。\n"
 
-#: src/tilda.c:519
+#: src/tilda.c:498
 #, c-format
 msgid "Creating directory:'%s'\n"
 msgstr "建立目錄：'%s'\n"
 
-#: src/tilda.c:662
+#: src/tilda.c:641
 msgid ""
 "Found style.css in the user config directory, applying user css style.\n"
 msgstr "在使用者的設定目錄中發現 style.css，套用使用者樣式中。\n"
 
-#: src/tilda.c:724
+#: src/tilda.c:703
 msgid "Migrating old config path to XDG folders\n"
 msgstr "正在將舊的設定檔搬移至 XDG 目錄\n"
 
-#: src/tilda.c:787
+#: src/tilda.c:766
 #, c-format
 msgid "Specified config file '%s' does not exist. Reverting to default path.\n"
 msgstr "指定的設定檔 '%s' 不存在。改採用預設的路徑。\n"
 
-#: src/tilda.c:878
+#: src/tilda.c:857 src/tilda-keybinding.c:409
 msgid ""
 "The keybinding you chose for \"Pull Down Terminal\" is invalid. Please "
 "choose another."
 msgstr "你選擇的「拉下終端機」快捷鍵無效。請選擇別的。"
 
-#: src/tilda_terminal.c:419
+#: src/tilda-keybinding.c:115
+#, fuzzy
+msgid "Action"
+msgstr "關閉 Tilda"
+
+#: src/tilda-keybinding.c:121
+msgid "Shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:306
+msgid "Enter keyboard shortcut"
+msgstr ""
+
+#: src/tilda-keybinding.c:417
+#, fuzzy, c-format
+msgid "The keybinding you chose for \"%s\" is invalid. Please choose another."
+msgstr "你選擇的「拉下終端機」快捷鍵無效。請選擇別的。"
+
+#: src/tilda_terminal.c:397
 #, c-format
 msgid "Problem reading link %s: %s\n"
 msgstr "跟隨符號連結 %s 失敗：%s\n"
 
-#: src/tilda_terminal.c:457
+#: src/tilda_terminal.c:435
 #, c-format
 msgid "Problem parsing custom command: %s\n"
 msgstr "解析自訂指令失敗：%s\n"
 
-#: src/tilda_terminal.c:458 src/tilda_terminal.c:500
+#: src/tilda_terminal.c:436 src/tilda_terminal.c:466
 msgid "Launching default shell instead\n"
 msgstr "作為替代，啟動預設的命令解釋器\n"
 
-#: src/tilda_terminal.c:499
+#: src/tilda_terminal.c:465
 #, c-format
 msgid "Unable to launch custom command: %s\n"
 msgstr "無法啟動自訂指令：%s\n"
 
-#: src/tilda_terminal.c:583
+#: src/tilda_terminal.c:537
 #, c-format
 msgid "Unable to launch default shell: %s\n"
 msgstr "無法啟動預設的命令解釋器：%s\n"
 
-#: src/tilda_terminal.c:1021
+#: src/tilda_terminal.c:940
 #, c-format
 msgid "Failed to launch the web browser. The command was `%s'\n"
 msgstr "無法啟動網頁瀏覽器。用到的指令是 `%s'\n"
 
-#: src/tilda_terminal.c:1074
+#: src/tilda_terminal.c:993
 msgid "Untitled"
 msgstr "無標題"
 
-#: src/tilda_terminal.c:1092
+#: src/tilda_terminal.c:1011
 msgid "Bad value for \"d_set_title\" in config file\n"
 msgstr "設定檔裡 \"d_set_title\" 的值不正確\n"
 
@@ -829,16 +860,16 @@ msgstr ""
 msgid "You have a bad tab_pos in your configuration file\n"
 msgstr "設定檔裡有個錯的定位點\n"
 
-#: src/tilda_window.c:839
+#: src/tilda_window.c:808
 #, c-format
 msgid "Unable to set tilda's icon: %s\n"
 msgstr "無法設定 Tilda 的圖示為：%s\n"
 
-#: src/tilda_window.c:1156
+#: src/tilda_window.c:1125
 msgid "Out of memory, cannot create tab\n"
 msgstr "記憶體不足。無法建立分頁\n"
 
-#: src/tilda_window.c:1276
+#: src/tilda_window.c:1245
 msgid "Are you sure you want to Quit?"
 msgstr ""
 
@@ -858,22 +889,38 @@ msgstr "XTerm"
 msgid "Rxvt"
 msgstr "Rxvt"
 
-#: src/wizard.c:340
+#: src/wizard.c:336
 #, c-format
 msgid "Tilda %d Config"
 msgstr "Tilda %d 設定值"
 
-#: src/wizard.c:794
-msgid "Invalid Cursor Type, reseting to default\n"
+#: src/wizard.c:767
+#, fuzzy
+msgid "Invalid Cursor Type, resetting to default\n"
 msgstr "無效的游標類型，已重設為預設\n"
 
-#: src/wizard.c:811
+#: src/wizard.c:785
 msgid "Invalid non-focus pull up behaviour, ignoring\n"
 msgstr "無效的未取得焦點拉起行為，已忽略\n"
 
-#: src/wizard.c:1276
+#: src/wizard.c:1221
 msgid "Invalid tab position setting, ignoring\n"
 msgstr "無效的 Tab 順序，已忽略\n"
+
+#~ msgid "Enable Antialiasing"
+#~ msgstr "啟用抗鋸齒"
+
+#~ msgid "Use Image for Background"
+#~ msgstr "使用圖像做為背景"
+
+#~ msgid "Scroll Background"
+#~ msgstr "捲動背景"
+
+#~ msgid "Use Antialiased Fonts"
+#~ msgstr "使用抗鋸齒字型"
+
+#~ msgid "Set Background Image"
+#~ msgstr "設定背景圖片"
 
 #~ msgid "Enable Double Buffering"
 #~ msgstr "啟用雙緩衝"
@@ -946,6 +993,3 @@ msgstr "無效的 Tab 順序，已忽略\n"
 
 #~ msgid "Problem parsing config file\n"
 #~ msgstr "解析設定檔時發生問題\n"
-
-#~ msgid "_New Tab"
-#~ msgstr "新分頁(_N)"

--- a/src/tilda-keybinding.c
+++ b/src/tilda-keybinding.c
@@ -112,13 +112,13 @@ tilda_keybinding_init (GtkBuilder *builder)
     GtkTreeViewColumn *column;
     GtkTreeIter iter;
 
-    column = gtk_tree_view_column_new_with_attributes (_ ("Action"), renderer,
+    column = gtk_tree_view_column_new_with_attributes (_("Action"), renderer,
                                                        "text", KB_TREE_ACTION,
                                                        NULL);
 
     gtk_tree_view_append_column (GTK_TREE_VIEW (tree_view), column);
 
-    column = gtk_tree_view_column_new_with_attributes (_ ("Shortcut"), renderer,
+    column = gtk_tree_view_column_new_with_attributes (_("Shortcut"), renderer,
                                                        "text", KB_TREE_SHORTCUT,
                                                        NULL);
 


### PR DESCRIPTION
I digged into translation infrastructure and made some improvements:

* Include `src/menu.ui` and `src/tilda-keybinding.c` in POTFILES so that those strings could appear in PO files
* Fix `_()` function calls in `src/tilda-keybinding.c` so that `gettext` could recognize them
* Refresh PO files
* Update `po/README` instruction
* Finish `zh_CN` (Simplified Chinese) translation