### PR TITLE
Change default browser command for better portability

### DIFF
--- a/src/configsys.c
+++ b/src/configsys.c
@@ -68,7 +68,7 @@ static cfg_opt_t config_opts[] = {
     CFG_STR("title", "Tilda", CFGF_NONE),
     CFG_STR("background_color", "white", CFGF_NONE),
     CFG_STR("working_dir", NULL, CFGF_NONE),
-    CFG_STR("web_browser", "x-www-browser", CFGF_NONE),
+    CFG_STR("web_browser", "xdg-open", CFGF_NONE),
     CFG_STR("increase_font_size_key", "<Control>equal", CFGF_NONE),
     CFG_STR("decrease_font_size_key", "<Control>minus", CFGF_NONE),
     CFG_STR("normalize_font_size_key", "<Control>0", CFGF_NONE),


### PR DESCRIPTION
x-www-browser is not standardized; not available on Fedora. 
Instead use xdg-open which is standardized and can open URLs as well.