### PR TITLE
Wayland crash fix (workaround)

### DIFF
--- a/src/tilda.c
+++ b/src/tilda.c
@@ -686,6 +686,9 @@ int main (int argc, char *argv[])
     g_log_set_default_handler (tilda_log_handler, NULL);
 #endif
 
+    /* Set supported backend to X11 */
+    gdk_set_allowed_backends ("x11");
+
     tilda_window tw;
     /* NULL set the tw pointers so we can get a clean exit on initialization failure */
     memset(&tw, 0, sizeof(tilda_window));


### PR DESCRIPTION
I don't know if you want to merge this, because a *real* wayland port is still needed. I just added a line to tell GTK this app uses the X11 backend. So it can run under the xorg-server-xwayland. 
So it doesn't crash anymore. 

**BUT**:
The global hotkey to toggle the view only works if your focus is on a x11 application (e.g. firefox). If you use a native  wayland application the global hotkey doesn't work. 
A fix for this would be a new option to toggle the visibility of a running tilda instance from command line. So you can add a global hotkey in gnome hotkey settings to toggle the view (DBUS support #30, #50 would be interesting for this).

greets