### PR TITLE
Change color of current character when using block cursor #344

### DIFF
--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -645,6 +645,7 @@ static gint tilda_term_config_defaults (tilda_term *tt)
     vte_terminal_set_cursor_blink_mode (VTE_TERMINAL(tt->vte_term),
             (config_getbool ("blinks"))?VTE_CURSOR_BLINK_ON:VTE_CURSOR_BLINK_OFF);
     vte_terminal_set_color_cursor (VTE_TERMINAL(tt->vte_term), &cc);
+    vte_terminal_set_color_cursor_foreground (VTE_TERMINAL(tt->vte_term), &bg);
 
     cursor_shape = config_getint("cursor_shape");
     if (cursor_shape < 0 || cursor_shape > 2) {

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -1537,6 +1537,8 @@ static void colorbutton_back_color_set_cb (GtkWidget *w, tilda_window *tw)
         tt = g_list_nth_data (tw->terms, i);
         vte_terminal_set_color_background (VTE_TERMINAL(tt->vte_term),
                                            &gdk_back_color);
+        vte_terminal_set_color_cursor_foreground (VTE_TERMINAL(tt->vte_term), 
+                                                  &gdk_back_color);
     }
 }
 


### PR DESCRIPTION
This resolve #344 

Now character under block cursor is more visible.

![blockcursor](https://user-images.githubusercontent.com/50671/41952512-d8b83618-7a02-11e8-8874-14502f3e58a8.png)
