### PR TITLE
Ham-handed manual resizing of window after every un-fullscreen

### DIFF
--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -172,6 +172,7 @@ void tilda_window_set_fullscreen(tilda_window *tw)
   }
   else {
     gtk_window_unfullscreen (GTK_WINDOW (tw->window));
+    gtk_window_resize (GTK_WINDOW(tw->window), config_getint ("max_width"), config_getint ("max_height"));
   }
 }
 


### PR DESCRIPTION
Fixes issues #297 #225 by manually applying size after unfullscreen. This particular bug has been bothering me for a while. Confirmed fixed in following environment:
```
james@james-5510:~/Projects/tilda$ wmctrl -m
Name: Mutter (Muffin)
Class: N/A
PID: N/A
Window manager's "showing the desktop" mode: N/A
james@james-5510:~/Projects/tilda$ lsb_release -a
No LSB modules are available.
Distributor ID: LinuxMint
Description:    Linux Mint 19 Tara
Release:        19
Codename:       tara
```