### PR TITLE
[search] migrate to PCRE2 regex handling

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -59,6 +59,7 @@ src_tilda_SOURCES = \
 		src/tomboykeybinder.h src/tomboykeybinder.c \
 		src/wizard.h src/wizard.c \
 		src/xerror.h src/xerror.c \
+		src/vte-util.h \
 		$(NULL)
 
 src_tilda_CFLAGS = \

--- a/src/tilda-search-box.c
+++ b/src/tilda-search-box.c
@@ -17,6 +17,7 @@
 
 #include "tilda-search-box.h"
 #include "tilda-enum-types.h"
+#include "vte-util.h"
 
 #define PCRE2_CODE_UNIT_WIDTH 0
 #include <pcre2.h>
@@ -41,6 +42,7 @@ struct _TildaSearchBox
 enum
 {
   SIGNAL_SEARCH,
+  SIGNAL_SEARCH_GREGEX,
   SIGNAL_FOCUS_OUT,
 
   LAST_SIGNAL
@@ -51,8 +53,77 @@ static guint signals[LAST_SIGNAL] = { 0 };
 G_DEFINE_TYPE (TildaSearchBox, tilda_search_box, GTK_TYPE_BOX)
 
 static void
-search (TildaSearchBox       *search,
-        TildaSearchDirection  direction)
+search_gregex (TildaSearchBox       *search,
+               TildaSearchDirection  direction)
+{
+    GtkEntry *entry;
+    GtkEntryBuffer *buffer;
+    GtkToggleButton *toggle_button;
+
+    GRegexCompileFlags compile_flags;
+    gboolean wrap_on_search;
+    gboolean is_regex;
+    const gchar *text;
+    gchar *pattern;
+    gboolean search_result;
+
+    GError *error;
+    GRegex *regex;
+
+    compile_flags = G_REGEX_OPTIMIZE;
+    wrap_on_search = FALSE;
+    toggle_button = GTK_TOGGLE_BUTTON (search->check_regex);
+    is_regex = gtk_toggle_button_get_active (toggle_button);
+    entry = GTK_ENTRY (search->entry);
+    buffer = GTK_ENTRY_BUFFER (gtk_entry_get_buffer (entry));
+    text = gtk_entry_buffer_get_text (buffer);
+
+    if (!search->last_search_successful)
+        wrap_on_search = TRUE;
+
+    if (is_regex)
+    {
+        compile_flags |= G_REGEX_MULTILINE;
+        pattern = g_strdup (text);
+    }
+    else
+        pattern = g_regex_escape_string (text, -1);
+
+    toggle_button = GTK_TOGGLE_BUTTON (search->check_match_case);
+    if (!gtk_toggle_button_get_active (toggle_button))
+    {
+        compile_flags |= G_REGEX_CASELESS;
+    }
+
+    error = NULL;
+    regex = g_regex_new (pattern, compile_flags,
+                         G_REGEX_MATCH_NEWLINE_ANY,
+                         &error);
+    g_free (pattern);
+
+    if (error)
+    {
+        GtkLabel *label = GTK_LABEL (search->label);
+        gtk_label_set_text (label, error->message);
+        gtk_widget_set_visible (search->label, TRUE);
+        g_error_free (error);
+        return;
+    }
+
+    g_signal_emit (search, signals[SIGNAL_SEARCH_GREGEX], 0,
+                   regex, direction, wrap_on_search, &search_result);
+
+    search->last_direction = direction;
+
+    gtk_widget_set_visible (search->label, !search_result);
+    search->last_search_successful = search_result;
+
+    g_regex_unref(regex);
+}
+
+static void
+search_vte_regex (TildaSearchBox       *search,
+                  TildaSearchDirection  direction)
 {
   GtkEntry *entry;
   GtkEntryBuffer *buffer;
@@ -125,6 +196,17 @@ search (TildaSearchBox       *search,
   search->last_search_successful = search_result;
 
   vte_regex_unref (regex);
+}
+
+static void
+search (TildaSearchBox       *search,
+        TildaSearchDirection  direction)
+{
+    if (VTE_CHECK_VERSION_RUMTIME (0, 56, 1)) {
+        search_vte_regex (search, direction);
+    } else {
+        search_gregex (search, direction);
+    }
 }
 
 static gboolean
@@ -225,6 +307,30 @@ tilda_search_box_class_init (TildaSearchBoxClass *box_class)
     g_signal_new ("search", TILDA_TYPE_SEARCH_BOX, G_SIGNAL_RUN_LAST, 0,
                   NULL, NULL, NULL, G_TYPE_BOOLEAN,
                   3, VTE_TYPE_REGEX, TILDA_TYPE_SEARCH_DIRECTION, G_TYPE_BOOLEAN);
+
+/**
+   * TildaSearchBox::search-gregex:
+   * @widget: the widget that received the signal
+   * @regex: the regular expression entered by the user
+   * @direction: the direction for the search
+   * @wrap_over: if the search should wrap over
+   *
+   * This signal is, emitted when the user performed a search action, such
+   * as clicking on the prev or next buttons or hitting enter.
+   *
+   * This widget does not actually perform the search, but leaves it to the
+   * users of this signal to perform the search based on the information
+   * provided to the signal handler.
+   *
+   * The user function needs to return %TRUE or %FALSE depending on
+   * whether the search was successful (i.e. a match was found).
+   *
+   * Returns: %TRUE if the search found a match, %FALSE otherwise.
+   */
+    signals[SIGNAL_SEARCH_GREGEX] =
+            g_signal_new ("search-gregex", TILDA_TYPE_SEARCH_BOX, G_SIGNAL_RUN_LAST, 0,
+                          NULL, NULL, NULL, G_TYPE_BOOLEAN,
+                          3, G_TYPE_REGEX, TILDA_TYPE_SEARCH_DIRECTION, G_TYPE_BOOLEAN);
 
   /**
    * TildaSearchBox::focus-out:

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -236,7 +236,7 @@ static void tilda_window_apply_transparency (tilda_window *tw, gboolean status)
 
 static gboolean
 search_cb (TildaSearchBox       *search,
-           GRegex               *regex,
+           VteRegex             *regex,
            TildaSearchDirection  direction,
            gboolean              wrap_on_search,
            tilda_window         *tw)
@@ -248,7 +248,7 @@ search_cb (TildaSearchBox       *search,
 
   vte_terminal = VTE_TERMINAL (term->vte_term);
 
-  vte_terminal_search_set_gregex (vte_terminal, regex, (GRegexMatchFlags) 0);
+  vte_terminal_search_set_regex (vte_terminal, regex, (GRegexMatchFlags) 0);
 
   vte_terminal_search_set_wrap_around (vte_terminal, wrap_on_search);
 

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -21,6 +21,7 @@
 #include "tilda_window.h"
 #include "tilda_terminal.h"
 #include "key_grabber.h"
+#include "vte-util.h"
 
 #include <math.h>
 #include <stdio.h>
@@ -232,6 +233,30 @@ static void tilda_window_apply_transparency (tilda_window *tw, gboolean status)
             tt = g_list_nth_data (tw->terms, i);
             vte_terminal_set_color_background(VTE_TERMINAL(tt->vte_term), &bg);
         }
+}
+
+static gboolean
+search_gregex_cb (TildaSearchBox       *search,
+                  GRegex               *regex,
+                  TildaSearchDirection  direction,
+                  gboolean              wrap_on_search,
+                  tilda_window         *tw)
+{
+    VteTerminal *vte_terminal;
+    tilda_term *term;
+
+    term = tilda_window_get_current_terminal (tw);
+
+    vte_terminal = VTE_TERMINAL (term->vte_term);
+
+    vte_terminal_search_set_gregex (vte_terminal, regex, (GRegexMatchFlags) 0);
+
+    vte_terminal_search_set_wrap_around (vte_terminal, wrap_on_search);
+
+    if (direction == SEARCH_BACKWARD)
+        return vte_terminal_search_find_previous (vte_terminal);
+    else
+        return vte_terminal_search_find_next (vte_terminal);
 }
 
 static gboolean
@@ -981,8 +1006,13 @@ gboolean tilda_window_init (const gchar *config_file, const gint instance, tilda
     gtk_box_pack_start (GTK_BOX (main_box), tw->notebook, TRUE, TRUE, 0);
     gtk_box_pack_start (GTK_BOX (main_box), tw->search, FALSE, TRUE, 0);
 
-    g_signal_connect (tw->search, "search",
-                      G_CALLBACK (search_cb), tw);
+    if (VTE_CHECK_VERSION_RUMTIME (0, 56, 1)) {
+        g_signal_connect (tw->search, "search",
+                          G_CALLBACK (search_cb), tw);
+    } else {
+        g_signal_connect (tw->search, "search-gregex",
+                          G_CALLBACK (search_gregex_cb), tw);
+    }
     g_signal_connect (tw->search, "focus-out",
                       G_CALLBACK (search_focus_out_cb), tw);
 

--- a/src/vte-util.h
+++ b/src/vte-util.h
@@ -1,0 +1,31 @@
+/*
+ * This is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Library General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef VTE_UTIL_H
+#define VTE_UTIL_H
+
+#include <glib.h>
+#include <vte/vte.h>
+
+G_BEGIN_DECLS
+
+#define VTE_CHECK_VERSION_RUMTIME(major,minor,micro) \
+        (vte_get_major_version () > (major) || \
+        (vte_get_major_version () == (major) && vte_get_minor_version () > (minor)) || \
+        (vte_get_major_version () == (major) && vte_get_minor_version () == (minor) && vte_get_micro_version () >= (micro)))
+
+G_END_DECLS
+
+#endif


### PR DESCRIPTION
The VTE `vte_terminal_search_set_gregex` function is deprecated in favor of the new `vte_regex_new_for_match`. However, when I compile this on Ubuntu 18.04 and invoke the search function, then I get an error that says; **PCRE2 not supported**, a search for PCRE2 and Ubuntu pretty quickly turns up some results pointing to problem with Ubuntu (see [Tilix][1] and [Launchpad Bug][2]). Thus I never merged this.

I am putting this code into this merge requests to give it a bit more visibility. It would be nice to get some feedback if this works for any body or on which version of Ubuntu and other distributions this actually works or causes problems. I usually make sure that Tilda can be compiled at least on the current LTS version of Ubuntu. This means that if I merge this in time to make it into Ubuntu 20.04 then the latest tilda version would no longer work on 18.04 which I would like to avoid.

@egmontkob Do you have any suggestions on how to deal with this? I am thinking if I should just leave the current regex support for some more time (e.g. merge this some time after Ubuntu 20.04 is released), or if I should invest the extra effort to add some compile time switches to get the newer regex code working on systems that support PCRE2.

[1]: https://github.com/gnunn1/tilix/issues/916
[2]: https://bugs.launchpad.net/ubuntu/+source/gnome-terminal/+bug/1666264