### PR TITLE
Allow ergonomic use of `ctrl+c` for copy

### DIFF
--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -666,7 +666,12 @@ static gint ccopy (tilda_window *tw)
         list = list->next;
     }
 
+    if ( ! vte_terminal_get_has_selection (VTE_TERMINAL (list->data)) ) {
+        return GDK_EVENT_PROPAGATE;
+    }
+
     vte_terminal_copy_clipboard_format (VTE_TERMINAL(list->data), VTE_FORMAT_TEXT);
+    vte_terminal_unselect_all (VTE_TERMINAL(list->data));
 
     return GDK_EVENT_STOP;
 }


### PR DESCRIPTION
This commit makes two small tweaks that allow for sensible use of ctrl+C
to copy:

1. It propagates the "copy" shortcut event if there is no text selected
in the terminal. This allows `ctrl+c` to be forwarded to the underlying
TTY to interrupt the foreground process as per usual.
2. It unselects the current selection when a clipboard copy is made.
This means that after you have used `ctrl+c` to copy the first time it
can be immediately used to interrupt the foreground process without
manually unselecting.