### PR TITLE
tilda.c: wayland dbus visibility toggler

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,17 @@ a new list based layout that is easier to use.
 ![Keybindings](images/tilda_keybindings-16-9.png)
 
 ## Supported Platforms
-Tilda currently works only on Xorg-based desktops. Previously that
+Tilda works only on Xorg-based desktops. Previously that
 meant that virtually all Linux distributions and some BSD's would be supported.
 Recently however, some Linux distributions
-(such as Ubuntu 17.10) have started to use Wayland as their
-default display server. Tilda currently does not support Wayland and will not
-work on such desktops. As a result it will fail to start.
-Patches that introduce wayland support for tilda are very welcome. Please
-look into the issue section or write me a mail if you would like to contribute
-to tilda.
+(such as Ubuntu 17.10 and later) have started to use Wayland as their
+default display server. Tilda can run on Wayland via the Xwayland plugin and
+the most recent version of Tilda has implemented a D-Bus interface, that
+allows to toggle the Tilda window via a D-Bus action. To enable this, users
+needs to start Tilda with the `--dbus` argument, and configure a (global)
+shortcut key within desktop-environment, passing `-T 0` argument to toggle
+the first instance. If additional tilda processes are running, then each
+process increments this value by one (i.e., `-T 1` for the second instance).
 
 # Installing Tilda
 

--- a/src/tilda-cli-options.c
+++ b/src/tilda-cli-options.c
@@ -8,6 +8,19 @@
 
 #include "debug.h"
 
+static GQuark tilda_error_quark (void);
+
+G_DEFINE_QUARK(tilda-config-error-quark, tilda_error)
+
+typedef enum {
+    TILDA_CONFIG_ERROR_BAD_INPUT, // Error for bad config argument
+} TildaConfigError;
+
+static gboolean toggle_option_cb (const gchar *option_name,
+                                  const gchar *value,
+                                  gpointer user_data,
+                                  GError **error);
+
 gboolean tilda_cli_options_parse_options (tilda_cli_options *cli_options,
                                           gint argc,
                                           gchar *argv[],
@@ -19,7 +32,7 @@ gboolean tilda_cli_options_parse_options (tilda_cli_options *cli_options,
     // *config_file must be non-null only if a configuration file path has been parsed
     DEBUG_ASSERT (*config_file == NULL);
 
-    /* All of the various command-line options */
+    /* All tilda command-line options */
     GOptionEntry cl_opts[] = {
             { "background-color",   'b', 0, G_OPTION_ARG_STRING,    &(cli_options->background_color),  N_("Set the background color"), NULL },
             { "command",            'c', 0, G_OPTION_ARG_STRING,    &(cli_options->command),           N_("Run a command at startup"), NULL },
@@ -34,15 +47,31 @@ gboolean tilda_cli_options_parse_options (tilda_cli_options *cli_options,
             { "y-pos",              'y', 0, G_OPTION_ARG_INT,       &(cli_options->y_pos),             N_("Y Position"), NULL },
             { "background-alpha",   't', 0, G_OPTION_ARG_INT,       &(cli_options->back_alpha),        N_("Opaqueness: 0-100%"), NULL },
             { "config",             'C', 0, G_OPTION_ARG_NONE,      &(cli_options->show_config),       N_("Show Configuration Wizard"), NULL },
-            { "dbus",               0, 0, G_OPTION_ARG_NONE,        &(cli_options->enable_dbus),       N_("Enable D-Bus interface for this instance"), NULL },
-            { NULL }
+            G_OPTION_ENTRY_NULL
+    };
+
+    GOptionEntry dbus_opts[] = {
+            { "dbus", 0, 0, G_OPTION_ARG_NONE,
+              &(cli_options->enable_dbus), N_("Enable D-Bus interface for this instance"), NULL },
+            { "toggle-window", 'T', G_OPTION_FLAG_OPTIONAL_ARG, G_OPTION_ARG_CALLBACK,
+              toggle_option_cb,  N_("Toggle N-th instance Window visibility and exit"), NULL
+            },
+            G_OPTION_ENTRY_NULL
     };
 
     /* Set up the command-line parser */
     GError *error = NULL;
     GOptionContext *context = g_option_context_new (NULL);
     g_option_context_add_main_entries (context, cl_opts, NULL);
+
+    /* Register a separate group for DBus related options. */
+    GOptionGroup *group = g_option_group_new ("dbus", "D-Bus Options:", "Show Tilda D-Bus Options", cli_options, NULL);
+    g_option_group_add_entries (group, dbus_opts);
+    g_option_context_add_group (context, group);
+
+    /* Register default GTK and GDK related option group. */
     g_option_context_add_group (context, gtk_get_option_group (FALSE));
+
     g_option_context_parse (context, &argc, &argv, &error);
     g_option_context_free (context);
 
@@ -87,5 +116,63 @@ tilda_cli_options *tilda_cli_options_new ()
         exit (EXIT_FAILURE);
     }
 
+    // instance id of the windows will be in range from 0 to N,
+    // defaults to -1 (unset) if option is not used.
+    options->toggle_window = -1;
+
     return options;
+}
+
+/**
+ * toggle_option_cb: A GOptionArgFunc which parses the toggle-window option
+ * argument. Using this toggle function allows us to assign a default value,
+ * if the user just specifies the option without a value. For example, the
+ * user may use '-T' instead of '-T 0', in this case we set the default
+ * instance_id to 0. Most users will want to use the default unless they
+ * are running multiple tilda instances and thus this makes the setup
+ * of toggle shortcuts easier.
+ */
+static gboolean toggle_option_cb (G_GNUC_UNUSED const gchar *option_name,
+                                  const gchar *value,
+                                  gpointer user_data,
+                                  GError **error)
+{
+    if (!user_data) {
+        g_error("Missing user_data pointer in toggle_option_cb function.");
+    }
+
+    tilda_cli_options *options = user_data;
+
+    if (!value || !value[0]) {
+        options->toggle_window = 0;
+        return TRUE;
+    }
+
+    char * parseEnd = NULL;
+
+    long instance_id = strtol(value, &parseEnd, 10);
+
+    if (parseEnd != NULL && *parseEnd != '\0') {
+        g_set_error(error, tilda_error_quark(), TILDA_CONFIG_ERROR_BAD_INPUT, "Could not parse the toggle argument. The argument must be a valid integer.");
+        return FALSE;
+    }
+
+    // sanity check for (gint) cast below. In practice, there will
+    // only ever be a few instances running, so this value will probably
+    // never be higher than 10, but to make the gint cast save, we check
+    // against INT_MAX
+    if (instance_id > INT_MAX) {
+        g_set_error (error, tilda_error_quark(), TILDA_CONFIG_ERROR_BAD_INPUT,
+                     "The toggle window option cannot must not be greater than %d, but value was %ld.", INT_MAX, instance_id);
+        return FALSE;
+    }
+
+    // if the user specified a negative value, then we default to 0.
+    if (instance_id < 0) {
+        instance_id = 0;
+    }
+
+    options->toggle_window = (gint) instance_id;
+
+    return TRUE;
 }

--- a/src/tilda-cli-options.h
+++ b/src/tilda-cli-options.h
@@ -10,6 +10,7 @@ struct tilda_cli_options {
     gchar *command;
     gchar *font;
     gchar *working_dir;
+    gint toggle_window;
     gint back_alpha;
     gint lines;
     gint x_pos;

--- a/src/tilda-dbus-actions.c
+++ b/src/tilda-dbus-actions.c
@@ -6,7 +6,14 @@
 #define TILDA_DBUS_ACTIONS_BUS_NAME "com.github.lanoxx.tilda.Actions"
 #define TILDA_DBUS_ACTIONS_OBJECT_PATH "/com/github/lanoxx/tilda/Actions"
 
-static gchar * tilda_dbus_actions_get_object_path (tilda_window *window);
+static gchar *
+tilda_dbus_actions_get_bus_name_for_instance (int instance_id);
+
+static gchar *
+tilda_dbus_actions_get_object_path (tilda_window *window);
+
+static gchar *
+tilda_dbus_actions_get_object_path_for_instance (int instance_id);
 
 static gboolean
 on_handle_toggle (TildaDbusActions *skeleton,
@@ -80,20 +87,67 @@ tilda_dbus_actions_init (tilda_window *window)
     return bus_identifier;
 }
 
+void tilda_dbus_actions_toggle (gint instance_id)
+{
+    GDBusConnection *conn = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, NULL);
+
+    GError * error = NULL;
+
+    if (!conn)
+    {
+        return;
+    }
+
+    gchar * name = tilda_dbus_actions_get_bus_name_for_instance (instance_id);
+    gchar * path = tilda_dbus_actions_get_object_path_for_instance (instance_id);
+
+    GVariant * result;
+
+    result = g_dbus_connection_call_sync (conn, name, path,
+                                          "com.github.lanoxx.tilda.Actions", "Toggle",
+                                          NULL, NULL, G_DBUS_CALL_FLAGS_NONE,
+                                          -1, NULL, &error);
+
+    if (error != NULL)
+    {
+        g_printerr ("Failed to toggle visibility for instance %d: %s\n",
+                    instance_id, error->message);
+        g_error_free (error);
+    } else {
+        g_variant_unref (result);
+    }
+
+    g_free (name);
+    g_free (path);
+
+    g_object_unref (conn);
+}
+
 gchar *
 tilda_dbus_actions_get_bus_name (tilda_window *window)
 {
-    return g_strdup_printf ("%s%d", TILDA_DBUS_ACTIONS_BUS_NAME, window->instance);
-}
-
-static gchar *
-tilda_dbus_actions_get_object_path (tilda_window *window)
-{
-    return g_strdup_printf ("%s%d", TILDA_DBUS_ACTIONS_OBJECT_PATH, window->instance);
+    return tilda_dbus_actions_get_bus_name_for_instance (window->instance);
 }
 
 void
 tilda_dbus_actions_finish (guint bus_identifier)
 {
     g_bus_unown_name (bus_identifier);
+}
+
+static gchar *
+tilda_dbus_actions_get_bus_name_for_instance (int instance_id) {
+    return g_strdup_printf ("%s%d", TILDA_DBUS_ACTIONS_BUS_NAME, instance_id);
+}
+
+static gchar *
+tilda_dbus_actions_get_object_path (tilda_window *window)
+{
+    return tilda_dbus_actions_get_object_path_for_instance (window->instance);
+}
+
+static gchar *
+tilda_dbus_actions_get_object_path_for_instance (int instance_id)
+{
+    return g_strdup_printf ("%s%d", TILDA_DBUS_ACTIONS_OBJECT_PATH, instance_id);
 }

--- a/src/tilda-dbus-actions.h
+++ b/src/tilda-dbus-actions.h
@@ -5,6 +5,8 @@
 
 guint  tilda_dbus_actions_init (tilda_window *window);
 
+void tilda_dbus_actions_toggle(gint instance_id);
+
 gchar *tilda_dbus_actions_get_bus_name (tilda_window *window);
 
 void   tilda_dbus_actions_finish (guint bus_identifier);

--- a/src/tilda.c
+++ b/src/tilda.c
@@ -230,13 +230,6 @@ int main (int argc, char *argv[])
     DEBUG_FUNCTION_MESSAGE ("main", "Using libvte version: %i.%i.%i",
                             VTE_MAJOR_VERSION, VTE_MINOR_VERSION, VTE_MICRO_VERSION);
 
-    /* Set supported backend to X11 */
-    gdk_set_allowed_backends ("x11");
-
-    tilda_window tw;
-    /* NULL set the tw pointers so we can get a clean exit on initialization failure */
-    memset(&tw, 0, sizeof(tilda_window));
-
     struct lock_info lock;
     gboolean need_wizard = FALSE;
     gchar *config_file;
@@ -270,16 +263,30 @@ int main (int argc, char *argv[])
         config_file = get_config_file_name (lock.instance);
     }
 
-    /* Initialize GTK. Any code that interacts with GTK (e.g. creating a widget)
-     * should come after this call. Gtk initialization should happen before we
-     * initialize the config file. */
-    gtk_init (&argc, &argv);
-
     /* Start up the configuration system and load from file */
     gint config_init_result = config_init (config_file);
 
     /* Set up possible overridden config options */
-    setup_config_from_cli_options(cli_options);
+    setup_config_from_cli_options (cli_options);
+
+    if (cli_options->toggle_window > -1)
+    {
+        tilda_dbus_actions_toggle (cli_options->toggle_window);
+
+        return EXIT_SUCCESS;
+    }
+
+    /* Set supported backend to X11 */
+    gdk_set_allowed_backends ("x11");
+
+    tilda_window tw;
+    /* NULL set the tw pointers so we can get a clean exit on initialization failure */
+    memset(&tw, 0, sizeof(tilda_window));
+
+    /* Initialize GTK. Any code that interacts with GTK (e.g. creating a widget)
+     * should come after this call. Gtk initialization should happen before we
+     * initialize the config file. */
+    gtk_init (&argc, &argv);
 
     if (config_init_result > 0) {
         show_startup_dialog (config_init_result);


### PR DESCRIPTION
in order to toggle visibility in Wayland, commands have to be sent via dbus. 
This commit introduces command line switch & function to call dbus method. 
It changes the order of tilda startup, as a window is not needed,
if we intend to exit right after sending cmd.

Lastly, there are a couple of formatting fixes, and readme entry.

In order to use it:     
- run Tilda with `--dbus`     
- set your preferred shortcut in OS with Wayland to run `tilda -T 1`  

Signed-off-by: Krzysztof Królczyk <Krzysztof.Krolczyk@o2.pl>