### PR TITLE
Allow configuring displaying bold text in bright colors

### DIFF
--- a/src/configsys.c
+++ b/src/configsys.c
@@ -172,6 +172,9 @@ static cfg_opt_t config_opts[] = {
 
     CFG_INT("back_alpha", 0xffff, CFGF_NONE),
 
+    /* Whether bold text is shown as bright colors */
+    CFG_BOOL("bold_is_bright", FALSE, CFGF_NONE),
+
     /* Whether to show the full tab title as a tooltip */
     CFG_BOOL("show_title_tooltip", FALSE, CFGF_NONE),
 

--- a/src/tilda.ui
+++ b/src/tilda.ui
@@ -2719,6 +2719,33 @@
                             <property name="top_attach">2</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkAlignment" id="alignment13">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="check_bold_is_bright">
+                            <property name="label" translatable="yes">Show bold text in bright colors</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="xalign">0</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                     <child type="label">

--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -714,6 +714,8 @@ static gint tilda_term_config_defaults (tilda_term *tt)
                              current_palette,
                              TILDA_COLOR_PALETTE_SIZE);
 
+    vte_terminal_set_bold_is_bright (VTE_TERMINAL(tt->vte_term), config_getbool ("bold_is_bright"));
+
     /** Bells **/
     vte_terminal_set_audible_bell (VTE_TERMINAL(tt->vte_term), config_getbool ("bell"));
 

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -1567,6 +1567,20 @@ static void colorbutton_palette_n_set_cb (GtkWidget *w, tilda_window *tw)
     }
 }
 
+static void check_bold_is_bright_toggled_cb (GtkWidget *w, tilda_window *tw)
+{
+    const gboolean status = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(w));
+    guint i;
+    tilda_term *tt;
+
+    config_setbool ("bold_is_bright", status);
+
+    for (i=0; i<g_list_length (tw->terms); i++) {
+        tt = g_list_nth_data (tw->terms, i);
+        vte_terminal_set_bold_is_bright (VTE_TERMINAL(tt->vte_term), status);
+    }
+}
+
 static void combo_scrollbar_position_changed_cb (GtkWidget *w, tilda_window *tw)
 {
     const gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
@@ -1932,6 +1946,8 @@ static void set_wizard_state_from_config (tilda_window *tw) {
         update_palette_color_button(i);
     }
 
+    CHECK_BUTTON ("check_bold_is_bright", "bold_is_bright");
+
     /* Scrolling Tab */
     initialize_scrollback_settings();
 
@@ -2075,6 +2091,7 @@ static void connect_wizard_signals (TildaWizard *wizard)
         CONNECT_SIGNAL (s,"color-set",colorbutton_palette_n_set_cb, tw);
         g_free (s);
     }
+    CONNECT_SIGNAL ("check_bold_is_bright","toggled",check_bold_is_bright_toggled_cb, tw);
 
     /* Scrolling Tab */
     CONNECT_SIGNAL ("combo_scrollbar_position","changed",combo_scrollbar_position_changed_cb, tw);


### PR DESCRIPTION
This pull request introduces a checkbox which controls "Bold is bright" VTE option in Tilda (issue #325).

A new checkbox "Show bold text in bright colors" is placed in the UI below "Color Palette" section in "Colors" tab in configuration window. The placement and naming of the checkbox is inspired by similar option in `xfce4-terminal` and `Terminator` terminal emulators.

---

This pull request *should* also include an update of the translation files, but I'm unsure how to proceed with them. Current `.po` files seem outdated, and updating them automatically by running `make update-po` results in a huge change set (about 3700 modified lines). By examining Polish translation, I can see that some of the translations are getting "lost" (`gettext` moves them to the end of `.po` file and comments them out). That's happening for other languages as well.

I also tried updating the `po/POTFILES.in` file (because some of the strings that get commented out are located in files not referenced in this file). While this results in less "lost" translations, I can see that some of the strings are assigned incorrectly in Polish translation. I can only assume it is probably happening elsewhere as well.

If you find the code change acceptable, could you advise how to proceed with the translations?