### PR TITLE
Option to insert new tabs after current tab instead of at the end

### DIFF
--- a/src/configsys.c
+++ b/src/configsys.c
@@ -81,6 +81,7 @@ static cfg_opt_t config_opts[] = {
     CFG_INT("tab_pos", 0, CFGF_NONE),
     CFG_BOOL("expand_tabs", FALSE, CFGF_NONE),
     CFG_BOOL("show_single_tab", FALSE, CFGF_NONE),
+    CFG_BOOL("insert_tab_after_current", FALSE, CFGF_NONE),
     CFG_INT("backspace_key", 0, CFGF_NONE),
     CFG_INT("delete_key", 1, CFGF_NONE),
     CFG_INT("d_set_title", 3, CFGF_NONE),

--- a/src/tilda.ui
+++ b/src/tilda.ui
@@ -2074,7 +2074,18 @@
                               </packing>
                             </child>
                             <child>
-                              <placeholder/>
+                              <object class="GtkCheckButton" id="check_insert_tab_after_current">
+                                <property name="label" translatable="yes">Insert New Tabs after Current Tab</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="xalign">0</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">2</property>
+                              </packing>
                             </child>
                           </object>
                         </child>

--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -135,7 +135,7 @@ register_match (VteRegex * regex,
     return tag;
 }
 
-struct tilda_term_ *tilda_term_init (struct tilda_window_ *tw)
+struct tilda_term_ *tilda_term_init (struct tilda_window_ *tw, gint index)
 {
     DEBUG_FUNCTION ("tilda_term_init");
     DEBUG_ASSERT (tw != NULL);
@@ -147,7 +147,7 @@ struct tilda_term_ *tilda_term_init (struct tilda_window_ *tw)
     term = g_new0 (tilda_term, 1);
 
     /* Add to GList list of tilda_term structures in tilda_window structure */
-    tw->terms = g_list_append (tw->terms, term);
+    tw->terms = g_list_insert (tw->terms, term, index);
 
     /* Check for a failed allocation */
     if (!term)

--- a/src/tilda_terminal.h
+++ b/src/tilda_terminal.h
@@ -56,6 +56,10 @@ enum delete_keys { ASCII_DELETE, DELETE_SEQUENCE, ASCII_BACKSPACE, AUTO };
  *
  * @param tw The main tilda window, which must be initialized.
  *
+ * @param index The location to insert the terminal. If this is negative, or is
+ * larger than the current number of terminals, the new terminal is added on to
+ * the end of the list.
+ *
  * Success: return a non-NULL struct tilda_term_ *.
  * Failure: return NULL.
  *
@@ -63,7 +67,7 @@ enum delete_keys { ASCII_DELETE, DELETE_SEQUENCE, ASCII_BACKSPACE, AUTO };
  *        when you are finished using it, and it has been removed from all GTK
  *        structures, such as the notebook.
  */
-struct tilda_term_ *tilda_term_init (struct tilda_window_ *tw);
+struct tilda_term_ *tilda_term_init (struct tilda_window_ *tw, gint position);
 
 /**
  * tilda_term_free ()

--- a/src/tilda_window.c
+++ b/src/tilda_window.c
@@ -1103,7 +1103,14 @@ gint tilda_window_add_tab (tilda_window *tw)
     GtkWidget *label;
     gint index;
 
-    tt = tilda_term_init (tw);
+    /* Determine where to insert the new terminal */
+    index = -1;
+    if (config_getbool ("insert_tab_after_current")) {
+        index = 1 + gtk_notebook_get_current_page (GTK_NOTEBOOK(tw->notebook));
+    }
+
+    /* Initialize the terminal */
+    tt = tilda_term_init (tw, index);
 
     if (tt == NULL)
     {
@@ -1112,10 +1119,9 @@ gint tilda_window_add_tab (tilda_window *tw)
         return FALSE;
     }
 
-    /* Create page and append to notebook */
+    /* Create page and insert it into the notebook */
     label = gtk_label_new (config_getstr("title"));
-    /* Strangely enough, prepend puts pages on the end */
-    index = gtk_notebook_append_page (GTK_NOTEBOOK(tw->notebook), tt->hbox, label);
+    index = gtk_notebook_insert_page (GTK_NOTEBOOK(tw->notebook), tt->hbox, label, index);
     gtk_notebook_set_current_page (GTK_NOTEBOOK(tw->notebook), index);
     gtk_notebook_set_tab_reorderable (GTK_NOTEBOOK(tw->notebook), tt->hbox, TRUE);
 

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -852,6 +852,13 @@ static void check_show_title_tooltip_toggled_cb (GtkWidget *w, tilda_window *tw)
     window_title_change_all (tw);
 }
 
+static void check_insert_tab_after_current_toggled_cb (GtkWidget *w, tilda_window *tw)
+{
+    const gboolean insert_tab_after_current = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w));
+
+    config_setbool("insert_tab_after_current", insert_tab_after_current);
+}
+
 static void entry_web_browser_changed (GtkWidget *w, tilda_window *tw) {
     const gchar *web_browser = gtk_entry_get_text (GTK_ENTRY(w));
 
@@ -1893,6 +1900,7 @@ static void set_wizard_state_from_config (tilda_window *tw) {
     CHECK_BUTTON ("check_expand_tabs", "expand_tabs");
     CHECK_BUTTON ("check_show_single_tab", "show_single_tab");
     CHECK_BUTTON ("check_show_title_tooltip", "show_title_tooltip");
+    CHECK_BUTTON ("check_insert_tab_after_current", "insert_tab_after_current");
 
     SET_SENSITIVE_BY_CONFIG_BOOL ("label_level_of_transparency","enable_transparency");
     SET_SENSITIVE_BY_CONFIG_BOOL ("spin_level_of_transparency","enable_transparency");
@@ -2056,6 +2064,7 @@ static void connect_wizard_signals (TildaWizard *wizard)
     CONNECT_SIGNAL ("check_expand_tabs","toggled",check_expand_tabs_toggled_cb, tw);
     CONNECT_SIGNAL ("check_show_single_tab","toggled",check_show_single_tab_toggled_cb, tw);
     CONNECT_SIGNAL ("check_show_title_tooltip","toggled",check_show_title_tooltip_toggled_cb, tw);
+    CONNECT_SIGNAL ("check_insert_tab_after_current","toggled",check_insert_tab_after_current_toggled_cb, tw);
 
     CONNECT_SIGNAL ("check_enable_transparency","toggled",check_enable_transparency_toggled_cb, tw);
     CONNECT_SIGNAL ("check_animated_pulldown","toggled",check_animated_pulldown_toggled_cb, tw);


### PR DESCRIPTION
I switched from `guake` to `tilda` and it's personally extremely jarring that the new tabs are spawned at the very end instead of immediately to the right of the currently selected tab.

This PR adds the self-explanatory "Insert New Tabs after Current Tab" option.