### PR TITLE
New Compatibility options

### DIFF
--- a/src/tilda.ui
+++ b/src/tilda.ui
@@ -271,6 +271,9 @@
     </columns>
     <data>
       <row>
+        <col id="0" translatable="yes">Terminal's erase setting</col>
+      </row>
+      <row>
         <col id="0" translatable="yes">ASCII DEL</col>
       </row>
       <row>
@@ -290,6 +293,9 @@
       <column type="gchararray"/>
     </columns>
     <data>
+      <row>
+        <col id="0" translatable="yes">Terminal's erase setting</col>
+      </row>
       <row>
         <col id="0" translatable="yes">ASCII DEL</col>
       </row>

--- a/src/tilda_terminal.c
+++ b/src/tilda_terminal.c
@@ -753,6 +753,9 @@ static gint tilda_term_config_defaults (tilda_term *tt)
     /** Keys **/
     switch (config_getint ("backspace_key"))
     {
+        case TTY:
+            vte_terminal_set_backspace_binding (VTE_TERMINAL(tt->vte_term), VTE_ERASE_TTY);
+            break;
         case ASCII_DELETE:
             vte_terminal_set_backspace_binding (VTE_TERMINAL(tt->vte_term), VTE_ERASE_ASCII_DELETE);
             break;
@@ -770,6 +773,9 @@ static gint tilda_term_config_defaults (tilda_term *tt)
 
     switch (config_getint ("delete_key"))
     {
+        case TTY:
+            vte_terminal_set_delete_binding (VTE_TERMINAL(tt->vte_term), VTE_ERASE_TTY);
+            break;
         case ASCII_DELETE:
             vte_terminal_set_delete_binding (VTE_TERMINAL(tt->vte_term), VTE_ERASE_ASCII_DELETE);
             break;

--- a/src/tilda_terminal.h
+++ b/src/tilda_terminal.h
@@ -47,7 +47,7 @@ struct tilda_term_
 };
 
 enum tilda_term_scrollbar_positions { RIGHT, LEFT, DISABLED };
-enum delete_keys { ASCII_DELETE, DELETE_SEQUENCE, ASCII_BACKSPACE, AUTO };
+enum delete_keys { TTY, ASCII_DELETE, DELETE_SEQUENCE, ASCII_BACKSPACE, AUTO };
 
 /**
  * tilda_term_init ()
@@ -101,4 +101,3 @@ G_END_DECLS
 /* vim: set ts=4 sts=4 sw=4 expandtab: */
 
 #endif /* TILDA_TERMINALN_H */
-

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -1448,7 +1448,7 @@ static void colorbutton_back_color_set_cb (GtkWidget *w, tilda_window *tw)
         tt = g_list_nth_data (tw->terms, i);
         vte_terminal_set_color_background (VTE_TERMINAL(tt->vte_term),
                                            &gdk_back_color);
-        vte_terminal_set_color_cursor_foreground (VTE_TERMINAL(tt->vte_term), 
+        vte_terminal_set_color_cursor_foreground (VTE_TERMINAL(tt->vte_term),
                                                   &gdk_back_color);
     }
 }
@@ -1677,7 +1677,8 @@ static void check_scroll_on_keystroke_toggled_cb (GtkWidget *w, tilda_window *tw
 static void combo_backspace_binding_changed_cb (GtkWidget *w, tilda_window *tw)
 {
     const gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
-    const gint keys[] = { VTE_ERASE_ASCII_DELETE,
+    const gint keys[] = { VTE_ERASE_TTY,
+                          VTE_ERASE_ASCII_DELETE,
                           VTE_ERASE_DELETE_SEQUENCE,
                           VTE_ERASE_ASCII_BACKSPACE,
                           VTE_ERASE_AUTO };
@@ -1695,7 +1696,8 @@ static void combo_backspace_binding_changed_cb (GtkWidget *w, tilda_window *tw)
 static void combo_delete_binding_changed_cb (GtkWidget *w, tilda_window *tw)
 {
     const gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
-    const gint keys[] = { VTE_ERASE_ASCII_DELETE,
+    const gint keys[] = { VTE_ERASE_TTY,
+                          VTE_ERASE_ASCII_DELETE,
                           VTE_ERASE_DELETE_SEQUENCE,
                           VTE_ERASE_ASCII_BACKSPACE,
                           VTE_ERASE_AUTO };


### PR DESCRIPTION
I made these changes by finding solution for #517

it's not, but could be useful also:

* added `VTE_ERASE_TTY` option for Backspace/Delete keys
* added `VTE_ERASE_AUTO` as defined but not visible in list yet 

I not sure about sort ordering where `VTE_ERASE_TTY` is now going first in list and could be default for new installations.
Commits does not includes localization files generated because doubts about menu item name.