### PR TITLE
key_grabber: call XResizeWindow when pulling down

### DIFF
--- a/src/key_grabber.c
+++ b/src/key_grabber.c
@@ -196,6 +196,11 @@ void tilda_window_set_active (tilda_window *tw)
         XRaiseWindow (x11_display, x11_window);
         gdk_x11_display_error_trap_pop_ignored(gdk_display_get_default());
     }
+    /* The window loses its size when called from a different monitor in XMonad */
+    GdkRectangle rectangle;
+    config_get_configured_window_size(&rectangle);
+    XResizeWindow(x11_display, x11_window, rectangle.width, rectangle.height);
+    XFlush(x11_display);
 }
 
 /* Process all pending GTK events, without returning to the GTK mainloop */


### PR DESCRIPTION
In a setting with XMonad and multiple monitors with different resolutions, when pulling down from a smaller monitor, the tilda window size becomes smaller and smaller. This adds a resize function after the call to fix the bug (might be gtk bug, though).

Note that XMonad is not tiling tilda but merely managing it.

Reproduction of the bug:
* Use XMonad as the window manager, set Tilda to floating
* Press the pulldown button the smaller screen which doesn't have tilda
* Expected outcome: tilda pulls down with its original size
* Actual outcome: tilda pulls down with the size proportionally smaller according to the smaller screen.