### PR TITLE
implement copy-on-selection functionality

### DIFF
--- a/src/configsys.c
+++ b/src/configsys.c
@@ -189,6 +189,9 @@ static cfg_opt_t config_opts[] = {
     CFG_BOOL("match_email_addresses", TRUE, CFGF_NONE),
     CFG_BOOL("match_numbers", TRUE, CFGF_NONE),
 
+    /* Whether to automatically copy selected text to clipboard */
+    CFG_BOOL("copy_on_selection", FALSE, CFGF_NONE),
+
     /* if set to TRUE, tilda will fall back to open
      * URIs with the 'web_browser' option. */
     CFG_BOOL("use_custom_web_browser", FALSE, CFGF_NONE),

--- a/src/tilda.ui
+++ b/src/tilda.ui
@@ -959,7 +959,7 @@
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="label-xalign">0</property>
                             <child>
-                              <!-- n-columns=2 n-rows=1 -->
+                              <!-- n-columns=2 n-rows=2 -->
                               <object class="GtkGrid" id="grid_select_by_word">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -976,7 +976,7 @@
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <property name="label" translatable="yes">Word Characters:</property>
+                                    <property name="label" translatable="yes">Select by Word Characters:</property>
                                     <property name="xalign">1</property>
                                   </object>
                                   <packing>
@@ -995,6 +995,22 @@
                                     <property name="top-attach">0</property>
                                   </packing>
                                 </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="check_copy_on_selection">
+                                    <property name="label" translatable="yes">Copy on Selection</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Automatically copy selected text to clipboard</property>
+                                    <property name="halign">start</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="width">2</property>
+                                  </packing>
+                                </child>
                               </object>
                             </child>
                             <child type="label">
@@ -1002,7 +1018,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="label" translatable="yes">&lt;b&gt;Select by Word&lt;/b&gt;</property>
+                                <property name="label" translatable="yes">&lt;b&gt;Selection&lt;/b&gt;</property>
                                 <property name="use-markup">True</property>
                               </object>
                             </child>

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -1674,6 +1674,12 @@ static void check_scroll_on_keystroke_toggled_cb (GtkWidget *w, tilda_window *tw
     }
 }
 
+static void check_copy_on_selection_toggled_cb (GtkWidget *w, tilda_window *tw)
+{
+    const gboolean status = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(w));
+    config_setbool ("copy_on_selection", status);
+}
+
 static void combo_backspace_binding_changed_cb (GtkWidget *w, tilda_window *tw)
 {
     const gint status = gtk_combo_box_get_active (GTK_COMBO_BOX(w));
@@ -1986,6 +1992,7 @@ static void initialize_scrollback_settings(void) {
 
     CHECK_BUTTON ("check_scroll_on_output", "scroll_on_output");
     CHECK_BUTTON ("check_scroll_on_keystroke", "scroll_on_key");
+    CHECK_BUTTON ("check_copy_on_selection", "copy_on_selection");
 }
 
 static void initialize_set_as_desktop_checkbox (void) {
@@ -2109,6 +2116,7 @@ static void connect_wizard_signals (TildaWizard *wizard)
     CONNECT_SIGNAL ("check_infinite_scrollback", "toggled", check_infinite_scrollback_toggled_cb, tw);
     CONNECT_SIGNAL ("check_scroll_on_output","toggled",check_scroll_on_output_toggled_cb, tw);
     CONNECT_SIGNAL ("check_scroll_on_keystroke","toggled",check_scroll_on_keystroke_toggled_cb, tw);
+    CONNECT_SIGNAL ("check_copy_on_selection","toggled",check_copy_on_selection_toggled_cb, tw);
 
     /* Compatibility Tab */
     CONNECT_SIGNAL ("combo_backspace_binding","changed",combo_backspace_binding_changed_cb, tw);


### PR DESCRIPTION
Implemented "Copy on Selection" functionality, when a text is automatically copied into a clipboard by mouse selection. This feature is optional and can be enabled on "Command and Title" tab.
Out of scope: localization.